### PR TITLE
🔒 Handle automatic logout on token expiration

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "framer-motion": "^12.33.0",
+    "jwt-decode": "^4.0.0",
     "lucide-react": "^0.562.0",
     "motion": "^12.29.2",
     "radix-ui": "^1.4.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,12 @@ import './App.css';
 
 import { GlobalErrorModal } from '@/components/GlobalErrorModal';
 import { RouterProvider } from 'react-router/dom';
+import { useAutoLogout } from './hooks/useAutoLogout';
 import { router } from './routes';
 
 export default function App() {
+  useAutoLogout();
+
   return (
     <>
       <RouterProvider router={router} />

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError } from 'axios';
+import { jwtDecode } from 'jwt-decode';
 import useAuthStore from '../hooks/useAuthStore';
 import { useErrorStore } from '../hooks/useErrorStore';
 
@@ -7,6 +8,9 @@ interface ApiErrorResponse {
   title: string;
   message: string;
 }
+
+// 5분 버퍼 (밀리초)
+const BUFFER_TIME = 5 * 60 * 1000;
 
 // 공통 설정을 가진 axios 인스턴스 생성
 const apiClient = axios.create({
@@ -17,30 +21,31 @@ const apiClient = axios.create({
 
 // 요청 인터셉터: 모든 요청 직전에 실행됨
 apiClient.interceptors.request.use((config) => {
-  const { token, tokenIssuedAt, logout } = useAuthStore.getState();
+  const { token, logout } = useAuthStore.getState();
 
-  // 22시간 만료 체크 (22 * 60 * 60 * 1000 ms)
-  const EXPIRY_TIME = 22 * 60 * 60 * 1000;
+  if (token) {
+    try {
+      const decoded = jwtDecode(token);
 
-  if (token && tokenIssuedAt) {
-    const isExpired = Date.now() - tokenIssuedAt >= EXPIRY_TIME;
+      if (decoded.exp) {
+        const expTimeMs = decoded.exp * 1000;
+        const now = Date.now();
 
-    if (isExpired) {
-      // 스토어 초기화 (로그아웃)
-      logout();
-
-      // 에러 모달 띄우기
-      const showError = useErrorStore.getState().showError;
-      showError(
-        '세션이 만료되어 자동으로 로그아웃 되었습니다. 다시 로그인해 주세요.',
-        '로그아웃 안내',
-        () => {
-          window.location.href = '/login';
+        // 만료시간 5분 전(혹은 이미 지남)이면 거부
+        if (expTimeMs - BUFFER_TIME - now <= 0) {
+          // 상태 관리 로그아웃 처리만 수행
+          // 에러 모달(showError)과 리다이렉트(window.location.href)는
+          // 최상단 App.tsx에 마운트된 useAutoLogout 훅에서 일괄적으로 처리하도록 위임함.
+          // 여기서 중복 호출 시 모달이 2번 뜨는 Race Condition 발생 가능성 차단
+          logout();
+          return Promise.reject(new Error('TOKEN_EXPIRED_LOCAL'));
         }
-      );
-
-      // 이번 요청은 취소
-      return Promise.reject(new Error('TOKEN_EXPIRED_LOCAL'));
+      }
+    } catch {
+      // 디코딩 실패 시 진행하지 않음 (서버가 거절하도록 두거나 여기서 바로 막음)
+      // 보안상 여기서 바로 막는 것이 안전
+      logout();
+      return Promise.reject(new Error('INVALID_TOKEN_FORMAT'));
     }
 
     config.headers.Authorization = `Bearer ${token}`;
@@ -59,14 +64,16 @@ apiClient.interceptors.response.use(
 
       // 1. 토큰 만료 등 특수한 경우 확인 버튼 액션 정의
       let onConfirm = undefined;
+      let confirmText = undefined;
       if (code === 'TOKEN_EXPIRED') {
         onConfirm = () => {
           window.location.href = '/login';
         };
+        confirmText = '다시 로그인하기';
       }
 
-      // 2. 스토어를 통해 모달 띄우기 (순서 주의: message, title, onConfirm)
-      showError(message, title || '오류 발생', onConfirm);
+      // 2. 스토어를 통해 모달 띄우기 (순서 주의: message, title, onConfirm, confirmText)
+      showError(message, title || '오류 발생', onConfirm, confirmText);
     } else {
       // 서버 응답 자체가 없는 경우 (네트워크 오류 등)
       showError(

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -17,9 +17,32 @@ const apiClient = axios.create({
 
 // 요청 인터셉터: 모든 요청 직전에 실행됨
 apiClient.interceptors.request.use((config) => {
-  const token = useAuthStore.getState().token;
+  const { token, tokenIssuedAt, logout } = useAuthStore.getState();
 
-  if (token) {
+  // 22시간 만료 체크 (22 * 60 * 60 * 1000 ms)
+  const EXPIRY_TIME = 22 * 60 * 60 * 1000;
+
+  if (token && tokenIssuedAt) {
+    const isExpired = Date.now() - tokenIssuedAt >= EXPIRY_TIME;
+
+    if (isExpired) {
+      // 스토어 초기화 (로그아웃)
+      logout();
+
+      // 에러 모달 띄우기
+      const showError = useErrorStore.getState().showError;
+      showError(
+        '세션이 만료되어 자동으로 로그아웃 되었습니다. 다시 로그인해 주세요.',
+        '로그아웃 안내',
+        () => {
+          window.location.href = '/login';
+        }
+      );
+
+      // 이번 요청은 취소
+      return Promise.reject(new Error('TOKEN_EXPIRED_LOCAL'));
+    }
+
     config.headers.Authorization = `Bearer ${token}`;
   }
 

--- a/src/components/GlobalErrorModal.tsx
+++ b/src/components/GlobalErrorModal.tsx
@@ -10,17 +10,30 @@ import {
 import { useErrorStore } from '@/hooks/useErrorStore';
 
 export function GlobalErrorModal() {
-  const { isOpen, title, message, onConfirm, closeError } = useErrorStore();
+  const { isOpen, title, message, onConfirm, closeError, confirmText } =
+    useErrorStore();
 
   const handleConfirm = () => {
     if (onConfirm) {
       onConfirm();
     }
-    closeError();
+
+    // 페이지 이동 등 무거운 작업이 발생할 때 리액트 렌더링 사이클이 꼬이면서
+    // 빈 모달이 깜빡이는 현상(Race condition)을 막기 위해 약간의 딜레이를 두고 닫음
+    setTimeout(() => {
+      closeError();
+    }, 100);
+  };
+
+  const handleOpenChange = (open: boolean) => {
+    if (!open) {
+      // 바깥 영역 클릭(오버레이) 등 수동으로 닫을 때만 즉시 처리
+      closeError();
+    }
   };
 
   return (
-    <AlertDialog open={isOpen} onOpenChange={closeError}>
+    <AlertDialog open={isOpen} onOpenChange={handleOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle className="text-destructive">
@@ -31,7 +44,9 @@ export function GlobalErrorModal() {
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogAction onClick={handleConfirm}>확인</AlertDialogAction>
+          <AlertDialogAction onClick={handleConfirm}>
+            {confirmText}
+          </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/src/hooks/useAuthStore.ts
+++ b/src/hooks/useAuthStore.ts
@@ -5,7 +5,6 @@ import { persist } from 'zustand/middleware';
 interface AuthState {
   user: User | null;
   token: string | null;
-  tokenIssuedAt: number | null; // 로그인 시점 (토큰 발급 시간) 저장
   isLoggedIn: boolean;
   // 로그인 시 유저 정보와 토큰을 함께 저장
   login: (user: User, token: string) => void;
@@ -26,7 +25,6 @@ const useAuthStore = create<AuthState>()(
     (set) => ({
       user: null,
       token: null,
-      tokenIssuedAt: null,
       isLoggedIn: false,
       guestRegistrations: {},
 
@@ -34,14 +32,12 @@ const useAuthStore = create<AuthState>()(
         set({
           user,
           token,
-          tokenIssuedAt: Date.now(),
           isLoggedIn: true,
         }),
       logout: () =>
         set({
           user: null,
           token: null,
-          tokenIssuedAt: null,
           isLoggedIn: false,
         }),
       updateUser: (user) => set({ user }),

--- a/src/hooks/useAuthStore.ts
+++ b/src/hooks/useAuthStore.ts
@@ -5,6 +5,7 @@ import { persist } from 'zustand/middleware';
 interface AuthState {
   user: User | null;
   token: string | null;
+  tokenIssuedAt: number | null; // 로그인 시점 (토큰 발급 시간) 저장
   isLoggedIn: boolean;
   // 로그인 시 유저 정보와 토큰을 함께 저장
   login: (user: User, token: string) => void;
@@ -25,11 +26,24 @@ const useAuthStore = create<AuthState>()(
     (set) => ({
       user: null,
       token: null,
+      tokenIssuedAt: null,
       isLoggedIn: false,
       guestRegistrations: {},
 
-      login: (user, token) => set({ user, token, isLoggedIn: true }),
-      logout: () => set({ user: null, token: null, isLoggedIn: false }),
+      login: (user, token) =>
+        set({
+          user,
+          token,
+          tokenIssuedAt: Date.now(),
+          isLoggedIn: true,
+        }),
+      logout: () =>
+        set({
+          user: null,
+          token: null,
+          tokenIssuedAt: null,
+          isLoggedIn: false,
+        }),
       updateUser: (user) => set({ user }),
       setGuestRegistration: (eventId, registrationId) =>
         set((state) => ({

--- a/src/hooks/useAutoLogout.ts
+++ b/src/hooks/useAutoLogout.ts
@@ -1,43 +1,67 @@
-import { useEffect } from 'react';
+import { jwtDecode } from 'jwt-decode';
+import { useEffect, useRef } from 'react';
 import useAuthStore from './useAuthStore';
 import { useErrorStore } from './useErrorStore';
 
-// 22시간 (밀리초)
-const EXPIRY_TIME = 22 * 60 * 60 * 1000;
+// 5분 버퍼 (밀리초) -> 만료 5분 전에 미리 로그아웃 시킴
+const BUFFER_TIME = 5 * 60 * 1000;
 
 export function useAutoLogout() {
-  const { token, tokenIssuedAt, logout } = useAuthStore();
+  const { token, logout } = useAuthStore();
   const showError = useErrorStore((state) => state.showError);
 
+  const isLoggingOut = useRef(false);
+
   useEffect(() => {
-    // 토큰이 없거나 발급 시간이 없으면 검사하지 않음
-    if (!token || !tokenIssuedAt) return;
+    if (!token) {
+      isLoggingOut.current = false;
+      return;
+    }
 
     const checkAndLogout = () => {
-      const timeElapsed = Date.now() - tokenIssuedAt;
-      const timeLeft = EXPIRY_TIME - timeElapsed;
+      if (isLoggingOut.current) return;
 
-      if (timeLeft <= 0) {
-        // 이미 만료된 경우 즉시 로그아웃
-        handleLogout();
-      } else {
-        // 아직 만료되지 않았다면 남은 시간 뒤에 로그아웃 하도록 타이머 설정
-        const timerId = setTimeout(() => {
+      try {
+        const decoded = jwtDecode(token);
+        if (!decoded.exp) return;
+
+        // 토큰 exp는 초 단위이므로 밀리초로 변환
+        const expTimeMs = decoded.exp * 1000;
+        const now = Date.now();
+
+        // (만료시간 - 버퍼) 시점까지 남은 시간
+        const timeLeftToLogout = expTimeMs - BUFFER_TIME - now;
+
+        if (timeLeftToLogout <= 0) {
+          // 이미 만료 시점을(혹은 버퍼 시점을) 지났다면 즉시 로그아웃
           handleLogout();
-        }, timeLeft);
+        } else {
+          // 아직 시간이 남았다면 타이머 설정
+          const timerId = setTimeout(() => {
+            handleLogout();
+          }, timeLeftToLogout);
 
-        return timerId;
+          return timerId;
+        }
+      } catch (error) {
+        // 토큰 디코딩 실패 시 (유효하지 않은 토큰) 강제 로그아웃
+        console.error('Invalid token format', error);
+        handleLogout();
       }
     };
 
     const handleLogout = () => {
+      if (isLoggingOut.current) return;
+      isLoggingOut.current = true;
+
       logout();
       showError(
-        '세션이 만료되어 자동으로 로그아웃 되었습니다. 다시 로그인해 주세요.',
+        '로그인 유지 시간이 만료되어 자동으로 로그아웃되었습니다.',
         '로그아웃 안내',
         () => {
           window.location.href = '/login';
-        }
+        },
+        '다시 로그인하기'
       );
     };
 
@@ -47,7 +71,6 @@ export function useAutoLogout() {
     // 2. 브라우저 탭 활성화(포커스 복귀) 시점에 다시 체크
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
-        // 기존 타이머 클리어 후 재계산
         if (timerId) clearTimeout(timerId);
         timerId = checkAndLogout();
       }
@@ -59,5 +82,5 @@ export function useAutoLogout() {
       if (timerId) clearTimeout(timerId);
       document.removeEventListener('visibilitychange', handleVisibilityChange);
     };
-  }, [token, tokenIssuedAt, logout, showError]);
+  }, [token, logout, showError]);
 }

--- a/src/hooks/useAutoLogout.ts
+++ b/src/hooks/useAutoLogout.ts
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+import useAuthStore from './useAuthStore';
+import { useErrorStore } from './useErrorStore';
+
+// 22시간 (밀리초)
+const EXPIRY_TIME = 22 * 60 * 60 * 1000;
+
+export function useAutoLogout() {
+  const { token, tokenIssuedAt, logout } = useAuthStore();
+  const showError = useErrorStore((state) => state.showError);
+
+  useEffect(() => {
+    // 토큰이 없거나 발급 시간이 없으면 검사하지 않음
+    if (!token || !tokenIssuedAt) return;
+
+    const checkAndLogout = () => {
+      const timeElapsed = Date.now() - tokenIssuedAt;
+      const timeLeft = EXPIRY_TIME - timeElapsed;
+
+      if (timeLeft <= 0) {
+        // 이미 만료된 경우 즉시 로그아웃
+        handleLogout();
+      } else {
+        // 아직 만료되지 않았다면 남은 시간 뒤에 로그아웃 하도록 타이머 설정
+        const timerId = setTimeout(() => {
+          handleLogout();
+        }, timeLeft);
+
+        return timerId;
+      }
+    };
+
+    const handleLogout = () => {
+      logout();
+      showError(
+        '세션이 만료되어 자동으로 로그아웃 되었습니다. 다시 로그인해 주세요.',
+        '로그아웃 안내',
+        () => {
+          window.location.href = '/login';
+        }
+      );
+    };
+
+    // 1. 마운트 시점에 체크 & 타이머 설정
+    let timerId = checkAndLogout();
+
+    // 2. 브라우저 탭 활성화(포커스 복귀) 시점에 다시 체크
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'visible') {
+        // 기존 타이머 클리어 후 재계산
+        if (timerId) clearTimeout(timerId);
+        timerId = checkAndLogout();
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+
+    return () => {
+      if (timerId) clearTimeout(timerId);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [token, tokenIssuedAt, logout, showError]);
+}

--- a/src/hooks/useErrorStore.ts
+++ b/src/hooks/useErrorStore.ts
@@ -4,8 +4,14 @@ interface ErrorState {
   isOpen: boolean;
   title: string;
   message: string;
+  confirmText: string;
   onConfirm?: () => void; // 확인 버튼 클릭 시 실행할 콜백 함수
-  showError: (message: string, title?: string, onConfirm?: () => void) => void;
+  showError: (
+    message: string,
+    title?: string,
+    onConfirm?: () => void,
+    confirmText?: string
+  ) => void;
   closeError: () => void;
 }
 
@@ -13,8 +19,15 @@ export const useErrorStore = create<ErrorState>((set) => ({
   isOpen: false,
   title: '오류 발생',
   message: '',
+  confirmText: '확인',
   onConfirm: undefined,
-  showError: (message, title = '오류 발생', onConfirm) =>
-    set({ isOpen: true, message, title, onConfirm }),
-  closeError: () => set({ isOpen: false, message: '', onConfirm: undefined }),
+  showError: (
+    message,
+    title = '오류 발생',
+    onConfirm,
+    confirmText = '확인'
+  ) => {
+    set({ isOpen: true, message, title, onConfirm, confirmText });
+  },
+  closeError: () => set({ isOpen: false }), // 리다이렉트 중 깜빡임 방지를 위해 내용 보존
 }));

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -26,8 +26,21 @@ export const authHandlers = [
 
       if (user) {
         await delay(500); // 실제 서버처럼 약간의 지연 시간 추가
+
+        // 테스트를 위해 만료 5분 10초(310초)짜리 진짜 JWT 구조 발급 (Base64 인코딩)
+        // Header: {"alg":"HS256","typ":"JWT"} -> eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9
+        const header = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9';
+        const payloadObj = {
+          sub: user.id.toString(),
+          iat: Math.floor(Date.now() / 1000),
+          exp: Math.floor(Date.now() / 1000) + 86400, // 현재 시간 + 24시간 만료
+        };
+        const payload = btoa(JSON.stringify(payloadObj));
+        const signature = 'mock-signature';
+        const mockJwtToken = `${header}.${payload}.${signature}`;
+
         return HttpResponse.json({
-          token: user.token,
+          token: mockJwtToken,
         });
       }
 

--- a/src/mocks/handlers/user.ts
+++ b/src/mocks/handlers/user.ts
@@ -1,5 +1,5 @@
 import type { GetMeResponse } from '@/types/users';
-import { http, HttpResponse, delay } from 'msw';
+import { http, HttpResponse } from 'msw';
 import { userDB } from '../db/user.db';
 import type { MockUser } from '../types';
 
@@ -22,24 +22,35 @@ export const userHandlers = [
         );
       }
 
-      // 헤더에서 토큰값만 추출 (예: "Bearer mock-token-1" -> "mock-token-1")
+      // 헤더에서 토큰값만 추출
       const requestToken = authHeader.split(' ')[1];
 
-      // 토큰을 기반으로 DB에서 유저 찾기
-      const user = userDB.find((u: MockUser) => u.token === requestToken);
+      try {
+        // 클라이언트에서 보낸 JWT 디코딩 (base64 부분 찾아서 파싱)
+        const payloadBase64 = requestToken.split('.')[1];
+        const payloadJson = atob(payloadBase64);
+        const decoded = JSON.parse(payloadJson);
+        const userId = Number(decoded.sub);
 
-      if (!user) {
+        // 토큰 payload의 sub(유저 ID)를 기반으로 DB에서 유저 찾기
+        const user = userDB.find((u: MockUser) => u.id === userId);
+
+        if (!user) {
+          return new HttpResponse(
+            { message: '해당 유저를 찾을 수 없습니다.' },
+            { status: 404 }
+          );
+        }
+
+        const { password, ...userResponse } = user as MockUser;
+
+        return HttpResponse.json(userResponse as GetMeResponse);
+      } catch (_error) {
         return new HttpResponse(
-          { message: '해당 유저를 찾을 수 없습니다.' },
-          { status: 404 }
+          { message: '유효하지 않은 토큰입니다.' },
+          { status: 401 }
         );
       }
-
-      await delay(300);
-
-      const { password, ...userResponse } = user as MockUser;
-
-      return HttpResponse.json(userResponse as GetMeResponse);
     }
   ),
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -6775,6 +6775,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jwt-decode@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "jwt-decode@npm:4.0.0"
+  checksum: 10c0/de75bbf89220746c388cf6a7b71e56080437b77d2edb29bae1c2155048b02c6b8c59a3e5e8d6ccdfd54f0b8bda25226e491a4f1b55ac5f8da04cfbadec4e546c
+  languageName: node
+  linkType: hard
+
 "kleur@npm:^3.0.3":
   version: 3.0.3
   resolution: "kleur@npm:3.0.3"
@@ -7232,6 +7239,7 @@ __metadata:
     class-variance-authority: "npm:^0.7.1"
     clsx: "npm:^2.1.1"
     framer-motion: "npm:^12.33.0"
+    jwt-decode: "npm:^4.0.0"
     knip: "npm:^5.59.1"
     lucide-react: "npm:^0.562.0"
     motion: "npm:^12.29.2"


### PR DESCRIPTION
### 📝 작업 내용

- 22시간이 지나면 자동으로 로그아웃 되게 설정했습니다. 로그인할 때, 로그인 시간을 `zustand`에 저장하고,, 이후 그 시간과 api 요청이 일어나는 시간을 비교하여 22시간이 지나면 자동으로 로그아웃 됩니다. 다음 3가지 방식으로 검사를 수행합니다.
  - API Interceptor 검사
  - 브라우저 탭 복귀 시점 감지
  - 타이머 기반 자동 감지
 - 브라우저 탭 복귀 시점 감지와 타이머 기반 자동 감지 모두 자바스크립트 엔진과 브라우저의 기본 제공 기능(Web API)을 활용해 `Event-Driven` 방식으로 작동하여 성능적인 악영향은 거의 없을 것이라고 합니다.
 - 추후 백엔드에서 `refreshToken`을 도입하면 자동 로그아웃 부분을 `refreshToken`을 요청하게 수정하면 될 것 같습니다.

### 📸 스크린샷 (선택)
<img width="1911" height="1293" alt="image" src="https://github.com/user-attachments/assets/a37aad8e-42be-4df4-8658-88418aff3c4c" />


### 🚀 리뷰 요구사항 (선택)
- 로그아웃 안내 모달이 나타나고 로그인 페이지로 이동하게 만들었는데, 모달 문구는 대충 만들었습니다. 혹시 더 좋은 의견 있으신가요...?
