### PR TITLE
✨ Add api for guest registration delete

### DIFF
--- a/src/api/registrations/registration.ts
+++ b/src/api/registrations/registration.ts
@@ -23,3 +23,8 @@ export async function patchRegistration(
   const response = await apiClient.patch(`/registrations/${id}`, data);
   return response.data;
 }
+
+// 신청 취소 (DELETE /api/registrations/:id)
+export async function deleteRegistration(id: string): Promise<void> {
+  await apiClient.delete(`/registrations/${id}`);
+}

--- a/src/hooks/useEventDetail.ts
+++ b/src/hooks/useEventDetail.ts
@@ -1,6 +1,7 @@
 import { deleteEvent, getEventDetail } from '@/api/events/event';
 import { getGuests, joinEvent } from '@/api/events/registrations';
 import {
+  deleteRegistration,
   getRegistrationDetail,
   patchRegistration,
 } from '@/api/registrations/registration';
@@ -136,9 +137,7 @@ export default function useEventDetail(id?: string) {
   const handleCancelEvent = async (registrationId: string) => {
     setLoading(true);
     try {
-      await patchRegistration(registrationId, {
-        status: 'CANCELED',
-      });
+      await deleteRegistration(registrationId);
       if (id) {
         removeGuestRegistration(id);
         await handleFetchDetail(id);

--- a/src/mocks/handlers/event.ts
+++ b/src/mocks/handlers/event.ts
@@ -83,6 +83,12 @@ export const eventHandlers = [
     });
   }),
 
+  // 신청 취소 (DELETE /registrations/:id)
+  http.delete(path('/registrations/:id'), async () => {
+    await delay(200);
+    return new HttpResponse(null, { status: 200 });
+  }),
+
   // 5. 일정 생성 (POST /events)
   http.post(path('/events'), async ({ request }) => {
     const body = (await request.json()) as CreateEventRequest;


### PR DESCRIPTION
### 📝 작업 내용

- 신청 취소 api를 추가했습니다.
- 신청 취소 로직에 연결하고, msw의 신청 취소도 수정했습니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 오늘 찬규님이 말씀해주신 내용인데, 현재 모집 종료된 일정에서도 참여 취소가 가능합니다. 만약 막는다고 하면 추가적인 수정이 필요할 것으로 예상됩니다...
- 이 PR과 연관 없는 일이긴 한데, dev 브렌치는 리뷰 요구 없이 바로 머지가 되는 것 같아 'Settings-Rules-Rulesets'에서 `main` 내용 복사해서 `dev`를 새로 만들었습니다.
