### PR TITLE
✨ Implementingl login redirect

### DIFF
--- a/src/components/AuthBox.tsx
+++ b/src/components/AuthBox.tsx
@@ -85,7 +85,18 @@ export default function AuthBox({ mode }: { mode: AuthMode }) {
       <span className="body-base text-center">
         소셜 계정으로 간편 {mode === 'sign-up' ? '회원가입' : '로그인'}
       </span>
-      <a href={GOOGLE_AUTH_URL} aria-label="Google로 회원가입">
+      <a
+        href={GOOGLE_AUTH_URL}
+        aria-label="Google로 회원가입"
+        onClick={() => {
+          if (!sessionStorage.getItem('redirectUrl')) {
+            sessionStorage.setItem(
+              'redirectUrl',
+              location.pathname + location.search
+            );
+          }
+        }}
+      >
         <ContinueWithGoogle />
       </a>
       <div className="flex w-full items-center gap-[12px]">

--- a/src/components/AuthBox.tsx
+++ b/src/components/AuthBox.tsx
@@ -1,5 +1,6 @@
 import { Button } from '@/components/ui/button';
 import { GOOGLE_AUTH_URL } from '@/constants/auth';
+import useAuthStore from '@/hooks/useAuthStore';
 import { Link } from 'react-router';
 
 function Separator() {
@@ -80,6 +81,7 @@ function ContinueWithGoogle() {
 type AuthMode = 'sign-up' | 'login';
 
 export default function AuthBox({ mode }: { mode: AuthMode }) {
+  const setRedirectUrl = useAuthStore((state) => state.setRedirectUrl);
   return (
     <div className="flex flex-col gap-6 items-center justify-center">
       <span className="body-base text-center">
@@ -89,11 +91,8 @@ export default function AuthBox({ mode }: { mode: AuthMode }) {
         href={GOOGLE_AUTH_URL}
         aria-label="Google로 회원가입"
         onClick={() => {
-          if (!sessionStorage.getItem('redirectUrl')) {
-            sessionStorage.setItem(
-              'redirectUrl',
-              location.pathname + location.search
-            );
+          if (!useAuthStore.getState().redirectUrl) {
+            setRedirectUrl(location.pathname + location.search);
           }
         }}
       >

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -33,12 +33,28 @@ export default function Header() {
         <div className="flex items-center gap-1.5">
           {!isLoggedIn || !user ? (
             <>
-              <Link to="/login">
+              <Link
+                to="/login"
+                onClick={() =>
+                  sessionStorage.setItem(
+                    'redirectUrl',
+                    location.pathname + location.search
+                  )
+                }
+              >
                 <Button variant="ghost" className="px-2 py-2">
                   <span className="single-line-body-base">로그인</span>
                 </Button>
               </Link>
-              <Link to="/">
+              <Link
+                to="/"
+                onClick={() =>
+                  sessionStorage.setItem(
+                    'redirectUrl',
+                    location.pathname + location.search
+                  )
+                }
+              >
                 <Button variant="ghost" className="px-2 py-2">
                   <span className="single-line-body-base">회원가입</span>
                 </Button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,11 +1,14 @@
 import ProfileButton from '@/components/ProfileButton';
 import { Button } from '@/components/ui/button';
 import useAuth from '@/hooks/useAuth';
+import useAuthStore from '@/hooks/useAuthStore';
 import { useEffect } from 'react';
 import { Link } from 'react-router';
 
 export default function Header() {
-  const { user, isLoggedIn, handleLogout, refreshUser } = useAuth();
+  const { user, handleLogout, refreshUser } = useAuth();
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+  const setRedirectUrl = useAuthStore((state) => state.setRedirectUrl);
 
   useEffect(() => {
     // 1. 로그인 상태가 아니면 타이머를 돌릴 필요가 없음
@@ -36,10 +39,7 @@ export default function Header() {
               <Link
                 to="/login"
                 onClick={() =>
-                  sessionStorage.setItem(
-                    'redirectUrl',
-                    location.pathname + location.search
-                  )
+                  setRedirectUrl(location.pathname + location.search)
                 }
               >
                 <Button variant="ghost" className="px-2 py-2">
@@ -49,10 +49,7 @@ export default function Header() {
               <Link
                 to="/"
                 onClick={() =>
-                  sessionStorage.setItem(
-                    'redirectUrl',
-                    location.pathname + location.search
-                  )
+                  setRedirectUrl(location.pathname + location.search)
                 }
               >
                 <Button variant="ghost" className="px-2 py-2">

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -38,7 +38,14 @@ export default function useAuth() {
         const { token } = await loginApi(data);
         const user = await getMeApi(token);
         login(user, token); // Zustand 스토어 업데이트
-        navigate('/'); // 메인 페이지로 이동
+
+        const redirectUrl = sessionStorage.getItem('redirectUrl');
+        if (redirectUrl) {
+          sessionStorage.removeItem('redirectUrl');
+          navigate(redirectUrl);
+        } else {
+          navigate('/'); // 메인 페이지로 이동
+        }
       } catch (error) {
         console.error('Login failed:', error);
       }
@@ -69,7 +76,14 @@ export default function useAuth() {
         const { token } = await socialApi(data);
         const user = await getMeApi(token);
         login(user, token);
-        navigate('/');
+
+        const redirectUrl = sessionStorage.getItem('redirectUrl');
+        if (redirectUrl) {
+          sessionStorage.removeItem('redirectUrl');
+          navigate(redirectUrl);
+        } else {
+          navigate('/');
+        }
       } catch (error) {
         console.error('Social login failed:', error);
       }

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -20,6 +20,7 @@ export default function useAuth() {
   const login = useAuthStore((state) => state.login);
   const logout = useAuthStore((state) => state.logout);
   const updateUser = useAuthStore((state) => state.updateUser);
+  const setRedirectUrl = useAuthStore((state) => state.setRedirectUrl);
 
   // 5. 로그아웃 로직 (handleLogout을 먼저 정의함)
   const handleLogout = useCallback(async () => {
@@ -39,18 +40,25 @@ export default function useAuth() {
         const user = await getMeApi(token);
         login(user, token); // Zustand 스토어 업데이트
 
-        const redirectUrl = sessionStorage.getItem('redirectUrl');
-        if (redirectUrl) {
-          sessionStorage.removeItem('redirectUrl');
+        const { redirectUrl, redirectTimestamp } = useAuthStore.getState();
+        const ONE_HOUR = 60 * 60 * 1000;
+
+        if (
+          redirectUrl &&
+          redirectTimestamp &&
+          Date.now() - redirectTimestamp < ONE_HOUR
+        ) {
+          setRedirectUrl(null);
           navigate(redirectUrl);
         } else {
+          setRedirectUrl(null);
           navigate('/'); // 메인 페이지로 이동
         }
       } catch (error) {
         console.error('Login failed:', error);
       }
     },
-    [login, navigate]
+    [login, navigate, setRedirectUrl]
   );
 
   // 2. 이메일 회원가입 로직
@@ -77,18 +85,25 @@ export default function useAuth() {
         const user = await getMeApi(token);
         login(user, token);
 
-        const redirectUrl = sessionStorage.getItem('redirectUrl');
-        if (redirectUrl) {
-          sessionStorage.removeItem('redirectUrl');
+        const { redirectUrl, redirectTimestamp } = useAuthStore.getState();
+        const ONE_HOUR = 60 * 60 * 1000;
+
+        if (
+          redirectUrl &&
+          redirectTimestamp &&
+          Date.now() - redirectTimestamp < ONE_HOUR
+        ) {
+          setRedirectUrl(null);
           navigate(redirectUrl);
         } else {
+          setRedirectUrl(null);
           navigate('/');
         }
       } catch (error) {
         console.error('Social login failed:', error);
       }
     },
-    [login, navigate]
+    [login, navigate, setRedirectUrl]
   );
 
   // 4. 내 정보 동기화

--- a/src/hooks/useAuthStore.ts
+++ b/src/hooks/useAuthStore.ts
@@ -18,6 +18,11 @@ interface AuthState {
   setGuestRegistration: (eventId: string, registrationId: string) => void;
   // 신청 취소 시 정보를 삭제하는 액션
   removeGuestRegistration: (eventId: string) => void;
+  // 소셜 로그인 및 회원가입 리다이렉트를 위한 상태
+  redirectUrl: string | null;
+  redirectTimestamp: number | null;
+  // 리다이렉트 정보를 저장하거나 초기화하는 액션
+  setRedirectUrl: (url: string | null) => void;
 }
 
 const useAuthStore = create<AuthState>()(
@@ -27,6 +32,8 @@ const useAuthStore = create<AuthState>()(
       token: null,
       isLoggedIn: false,
       guestRegistrations: {},
+      redirectUrl: null,
+      redirectTimestamp: null,
 
       login: (user, token) =>
         set({
@@ -57,6 +64,12 @@ const useAuthStore = create<AuthState>()(
           const newRegistrations = { ...state.guestRegistrations };
           delete newRegistrations[eventId];
           return { guestRegistrations: newRegistrations };
+        }),
+
+      setRedirectUrl: (url) =>
+        set({
+          redirectUrl: url,
+          redirectTimestamp: url ? Date.now() : null,
         }),
     }),
     {

--- a/src/routes/EventRegister.tsx
+++ b/src/routes/EventRegister.tsx
@@ -2,6 +2,7 @@ import LoadingSkeleton from '@/components/LoadingSkeleton';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import useAuthStore from '@/hooks/useAuthStore';
 import type { JoinEventRequest } from '@/types/events';
 import { ChevronLeftIcon } from 'lucide-react';
 import { useEffect, useState } from 'react';
@@ -13,6 +14,7 @@ import useEventDetail from '../hooks/useEventDetail';
 export default function EventRegister() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const setRedirectUrl = useAuthStore((state) => state.setRedirectUrl);
   const { loading, data, handleFetchDetail, handleJoinEvent } =
     useEventDetail();
 
@@ -41,7 +43,7 @@ export default function EventRegister() {
 
   const { event } = data;
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const onRegisterSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!id) return;
 
@@ -96,7 +98,10 @@ export default function EventRegister() {
         <ShortEventDetailContent event={event} />
 
         {/* 신청 폼 섹션 */}
-        <form onSubmit={handleSubmit} className="w-full flex flex-col gap-12">
+        <form
+          onSubmit={onRegisterSubmit}
+          className="w-full flex flex-col gap-12"
+        >
           <div className="space-y-10">
             <div className="space-y-8 border border-gray-100 rounded-2xl p-6 shadow-sm">
               <div className="grid w-full items-center gap-3 ">
@@ -145,7 +150,7 @@ export default function EventRegister() {
                 variant="moiming"
                 className="w-[75%] h-14 bg-blue-400 text-base"
                 onClick={() => {
-                  sessionStorage.setItem('redirectUrl', `/event/${id}`);
+                  setRedirectUrl(`/event/${id}`);
                   navigate('/login');
                 }}
               >
@@ -156,7 +161,7 @@ export default function EventRegister() {
                 type="button"
                 variant="moimingOutline"
                 onClick={() => {
-                  sessionStorage.setItem('redirectUrl', `/event/${id}`);
+                  setRedirectUrl(`/event/${id}`);
                   navigate('/');
                 }}
                 className="w-[75%] h-14 text-base border-1"
@@ -169,9 +174,7 @@ export default function EventRegister() {
               {/* 구글 로그인 */}
               <a
                 href={GOOGLE_AUTH_URL}
-                onClick={() =>
-                  sessionStorage.setItem('redirectUrl', `/event/${id}`)
-                }
+                onClick={() => setRedirectUrl(`/event/${id}`)}
                 className="w-14 h-14 flex items-center justify-center border border-gray-200 rounded-full hover:bg-gray-50 transition-all shadow-sm"
                 aria-label="Google 로그인"
               >

--- a/src/routes/EventRegister.tsx
+++ b/src/routes/EventRegister.tsx
@@ -144,7 +144,10 @@ export default function EventRegister() {
                 type="button"
                 variant="moiming"
                 className="w-[75%] h-14 bg-blue-400 text-base"
-                onClick={() => navigate('/login')}
+                onClick={() => {
+                  sessionStorage.setItem('redirectUrl', `/event/${id}`);
+                  navigate('/login');
+                }}
               >
                 로그인하기
               </Button>
@@ -152,7 +155,10 @@ export default function EventRegister() {
               <Button
                 type="button"
                 variant="moimingOutline"
-                onClick={() => navigate('/register')}
+                onClick={() => {
+                  sessionStorage.setItem('redirectUrl', `/event/${id}`);
+                  navigate('/');
+                }}
                 className="w-[75%] h-14 text-base border-1"
               >
                 계정 만들기
@@ -163,6 +169,9 @@ export default function EventRegister() {
               {/* 구글 로그인 */}
               <a
                 href={GOOGLE_AUTH_URL}
+                onClick={() =>
+                  sessionStorage.setItem('redirectUrl', `/event/${id}`)
+                }
                 className="w-14 h-14 flex items-center justify-center border border-gray-200 rounded-full hover:bg-gray-50 transition-all shadow-sm"
                 aria-label="Google 로그인"
               >


### PR DESCRIPTION
### 📝 작업 내용

- 로그인 / 소셜 로그인 / 회원가입 시 현재 페이지를 `zustand`에 저장하고, 성공 시 다시 기존 페이지로 돌아오는 로직을 추가합니다.
- 일정 신청 페이지(EventRegister)에서 로그인 등을 하면, public id를 이용해서 일정 상세 페이지로 리다이렉트 됩니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 소셜 로그인과 회원가입은 로컬에서 확인해보지 못했습니다...
