### PR TITLE
💚 Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,19 +4,19 @@ on:
   pull_request:
     branches:
       - main
+      - dev
   push:
     branches:
       - main
+      - dev
 
 jobs:
   ci:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20.11.1'
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
       - name: Install dependencies
         run: yarn install
       - name: Format package.json


### PR DESCRIPTION
### 📝 작업 내용

- CI 적용 대상에 `dev` 브랜치를 추가했습니다.
- CI에서 사용하는 액션 `checkout`과 `setup-node`를 버전 6으로 올렸습니다. 종전에 사용하던 버전 4는 Node 20에 바탕을 두고 있는데, [깃허브 액션에서 Node 20의 지원이 곧 종료](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)되기 때문입니다.

### 📸 스크린샷

없음

### 🚀 리뷰 요구사항

없음