### PR TITLE
✨ Adding event tab & infinite scroll to home

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,6 +12,7 @@
 @layer base {
   html,
   body {
+    scrollbar-gutter: stable;
     @apply h-full;
 
     font-family:

--- a/src/api/events/me.ts
+++ b/src/api/events/me.ts
@@ -2,8 +2,10 @@ import type { MyEventsResponse } from '@/types/events';
 import apiClient from '../apiClient';
 
 // 내가 생성한 일정 목록 (GET /api/events/me)
-export default async function getMyEvents() {
-  const response = await apiClient.get<MyEventsResponse>(`/events/me`);
+export default async function getMyEvents(cursor?: string) {
+  const response = await apiClient.get<MyEventsResponse>(`/events/me`, {
+    params: { cursor },
+  });
 
   return {
     data: response.data,

--- a/src/api/registrations/me.ts
+++ b/src/api/registrations/me.ts
@@ -2,7 +2,15 @@ import apiClient from '@/api/apiClient';
 import type { MyRegistrationsResponse } from '@/types/registrations';
 
 // 내가 신청한 일정 조회 (GET /api/registrations/me)
-export default async function getMyRegistrations(): Promise<MyRegistrationsResponse> {
-  const response = await apiClient.get('/registrations/me');
+export default async function getMyRegistrations(
+  page: number = 0,
+  size: number = 5
+): Promise<MyRegistrationsResponse> {
+  const response = await apiClient.get<MyRegistrationsResponse>(
+    '/registrations/me',
+    {
+      params: { page, size },
+    }
+  );
   return response.data;
 }

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,6 +1,7 @@
 import EventCard from '@/components/EventCard';
 import { Button } from '@/components/ui/button';
 import type { MyEvent } from '@/types/events';
+import type { MyRegistration } from '@/types/registrations';
 import { CalendarIcon, Plus } from 'lucide-react';
 import { useNavigate } from 'react-router';
 
@@ -21,21 +22,38 @@ function NewEventButton() {
   );
 }
 
-export default function Dashboard({ events = [] }: { events: MyEvent[] }) {
-  if (!events || events.length === 0) {
+interface DashboardProps {
+  events?: MyEvent[];
+  registrations?: MyRegistration[];
+  type: 'hosted' | 'joined';
+}
+
+export default function Dashboard({
+  events = [],
+  registrations = [],
+  type,
+}: DashboardProps) {
+  const isHosted = type === 'hosted';
+  const dataList = isHosted ? events : registrations;
+
+  if (!dataList || dataList.length === 0) {
     return (
-      <div className="flex w-full max-w-md flex-col items-center justify-center">
-        <div className="flex flex-col gap-5 items-center">
+      <div className="flex flex-1 w-full flex-col items-center justify-center pt-10">
+        <div className="flex flex-col gap-5 items-center w-full max-w-md mx-auto">
           <div className="flex flex-col gap-1">
-            <h1 className="text-center">생성된 일정이 없어요.</h1>
+            <h1 className="text-center">
+              {isHosted ? '생성된 일정이 없어요.' : '참여한 일정이 없어요.'}
+            </h1>
             <span className="body-base text-[#757575] text-center">
-              일정을 만들고 모임을 시작해보세요.
+              {isHosted
+                ? '일정을 만들고 모임을 시작해보세요.'
+                : '모임에 참여하고 일정을 확인해보세요.'}
             </span>
           </div>
           <div className="flex px-1 py-1 justify-center">
             <CalendarIcon stroke="#B3B3B3" width="48" height="48" />
           </div>
-          <NewEventButton />
+          {isHosted && <NewEventButton />}
         </div>
       </div>
     );
@@ -43,11 +61,23 @@ export default function Dashboard({ events = [] }: { events: MyEvent[] }) {
 
   return (
     <div className="flex w-full flex-col gap-4 items-end">
-      <NewEventButton />
+      {isHosted && <NewEventButton />}
       <div className="flex w-full flex-col gap-4">
-        {events.map((event) => (
-          <EventCard event={event} />
-        ))}
+        {isHosted
+          ? events.map((event) => (
+              <EventCard
+                key={`event-${event.publicId}`}
+                event={event}
+                type="hosted"
+              />
+            ))
+          : registrations.map((reg) => (
+              <EventCard
+                key={`reg-${reg.publicId}`}
+                registration={reg}
+                type="joined"
+              />
+            ))}
       </div>
     </div>
   );

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -1,26 +1,8 @@
 import EventCard from '@/components/EventCard';
-import { Button } from '@/components/ui/button';
+import NewEventButton from '@/components/NewEventButton';
 import type { MyEvent } from '@/types/events';
 import type { MyRegistration } from '@/types/registrations';
-import { CalendarIcon, Plus } from 'lucide-react';
-import { useNavigate } from 'react-router';
-
-function NewEventButton() {
-  const navigate = useNavigate();
-
-  const onNewEventClicked = () => {
-    navigate('/new-event');
-  };
-
-  return (
-    <Button onClick={onNewEventClicked} className="h-[40px]">
-      <Plus stroke="#F1F6FD" width="16" height="16" />
-      <span className="single-line-body-base text-primary-foreground">
-        새 일정 만들기
-      </span>
-    </Button>
-  );
-}
+import { CalendarIcon } from 'lucide-react';
 
 interface DashboardProps {
   events?: MyEvent[];
@@ -61,7 +43,6 @@ export default function Dashboard({
 
   return (
     <div className="flex w-full flex-col gap-4 items-end">
-      {isHosted && <NewEventButton />}
       <div className="flex w-full flex-col gap-4">
         {isHosted
           ? events.map((event) => (

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -1,6 +1,7 @@
 import TagMini from '@/components/TagMini';
 import { Button } from '@/components/ui/button';
 import type { MyEvent } from '@/types/events';
+import type { MyRegistration } from '@/types/registrations';
 import { getPeriod } from '@/utils/date';
 import {
   Calendar,
@@ -12,17 +13,34 @@ import {
 import { Link } from 'react-router';
 import { toast } from 'sonner';
 
-export default function EventCard({ event }: { event: MyEvent }) {
-  const {
-    publicId,
-    title,
-    startsAt,
-    endsAt,
-    capacity,
-    totalApplicants,
-    registrationStartsAt,
-    registrationEndsAt,
-  } = event;
+interface EventCardProps {
+  event?: MyEvent;
+  registration?: MyRegistration;
+  type: 'hosted' | 'joined';
+}
+
+export default function EventCard({
+  event,
+  registration,
+  type,
+}: EventCardProps) {
+  const isHosted = type === 'hosted';
+
+  // Extract values based on the object type
+  const publicId = isHosted ? event?.publicId : registration?.publicId;
+  const title = isHosted ? event?.title : registration?.title;
+  const startsAt = isHosted ? event?.startsAt : registration?.startAt;
+  const endsAt = isHosted ? event?.endsAt : registration?.endAt;
+  const capacity = isHosted ? event?.capacity : registration?.capacity;
+  const applicants = isHosted
+    ? event?.totalApplicants
+    : registration?.registrationCnt;
+  const regStart = isHosted
+    ? event?.registrationStartsAt
+    : registration?.registrationStart;
+  const regEnd = isHosted
+    ? event?.registrationEndsAt
+    : registration?.registrationDeadline;
 
   const joinLink = `${window.location.origin}/event/${publicId}`;
 
@@ -34,9 +52,39 @@ export default function EventCard({ event }: { event: MyEvent }) {
   };
 
   const getStatusTag = () => {
+    // For joined events, we might want to prioritize showing their application status
+    if (!isHosted && registration?.status) {
+      if (registration.status === 'CONFIRMED') {
+        return (
+          <TagMini
+            background="bg-[#CFF7D3]"
+            foreground="text-[#02542D]"
+            content="참여 확정"
+          />
+        );
+      } else if (registration.status === 'WAITLISTED') {
+        return (
+          <TagMini
+            background="bg-[#E5F0FF]"
+            foreground="text-[#0055CC]"
+            content={`대기 ${registration.waitingNum}번`}
+          />
+        );
+      } else if (registration.status === 'CANCELED') {
+        return (
+          <TagMini
+            background="bg-[#FDD3D0]"
+            foreground="text-[#900B09]"
+            content="참여 취소"
+          />
+        );
+      }
+    }
+
+    if (!regStart || !regEnd) return null;
     const nowDate = new Date();
-    const startDate = new Date(registrationStartsAt);
-    const endDate = new Date(registrationEndsAt);
+    const startDate = new Date(regStart);
+    const endDate = new Date(regEnd);
 
     if (nowDate < startDate) {
       return (
@@ -70,7 +118,7 @@ export default function EventCard({ event }: { event: MyEvent }) {
       key={`card-${publicId}`}
       className="w-full rounded-lg border border-border"
     >
-      <Link to={`/event/${event.publicId}`}>
+      <Link to={`/event/${publicId}`}>
         <div className="flex flex-col px-4 pt-4 pb-3 gap-3">
           <h1>{title}</h1>
           <div className="flex flex-col gap-1">
@@ -90,19 +138,18 @@ export default function EventCard({ event }: { event: MyEvent }) {
               <User stroke="#757575" width="16" />
               <span className="body-base text-[#757575]">정원</span>
               <span className="body-base">
-                {totalApplicants}/{capacity}명
-                {/* {confirmedCount}/{capacity}명 (대기자 {waitlistCount}명) */}
+                {applicants}/{capacity}명
               </span>
             </div>
           </div>
         </div>
       </Link>
       <div className="flex flex-col px-6 pt-3 pb-2 gap-1 bg-muted w-full rounded-b-lg items-start">
-        <Link to={`/event/${event.publicId}`}>
+        <Link to={`/event/${publicId}`}>
           <div className="flex gap-1.5">
             <Clock stroke="#757575" width="16" />
             <span className="body-base">
-              신청 기간: {getPeriod(registrationStartsAt, registrationEndsAt)}
+              신청 기간: {getPeriod(regStart, regEnd)}
             </span>
           </div>
         </Link>

--- a/src/components/NewEventButton.tsx
+++ b/src/components/NewEventButton.tsx
@@ -1,0 +1,20 @@
+import { Button } from '@/components/ui/button';
+import { Plus } from 'lucide-react';
+import { useNavigate } from 'react-router';
+
+export default function NewEventButton() {
+  const navigate = useNavigate();
+
+  const onNewEventClicked = () => {
+    navigate('/new-event');
+  };
+
+  return (
+    <Button onClick={onNewEventClicked} className="h-[40px]">
+      <Plus stroke="#F1F6FD" width="16" height="16" />
+      <span className="single-line-body-base text-primary-foreground">
+        새 일정 만들기
+      </span>
+    </Button>
+  );
+}

--- a/src/hooks/useInfiniteMyEvents.ts
+++ b/src/hooks/useInfiniteMyEvents.ts
@@ -1,0 +1,20 @@
+import getMyEvents from '@/api/events/me';
+import type { MyEventsResponse } from '@/types/events';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export default function useInfiniteMyEvents() {
+  return useInfiniteQuery<MyEventsResponse, Error>({
+    queryKey: ['myEvents'],
+    queryFn: async ({ pageParam = undefined }) => {
+      const { data } = await getMyEvents(pageParam as string | undefined);
+      return data;
+    },
+    getNextPageParam: (lastPage) => {
+      if (lastPage.hasNext) {
+        return lastPage.nextCursor;
+      }
+      return undefined;
+    },
+    initialPageParam: undefined,
+  });
+}

--- a/src/hooks/useInfiniteMyRegistrations.ts
+++ b/src/hooks/useInfiniteMyRegistrations.ts
@@ -1,0 +1,25 @@
+import getMyRegistrations from '@/api/registrations/me';
+import type { MyRegistrationsResponse } from '@/types/registrations';
+import { useInfiniteQuery } from '@tanstack/react-query';
+
+export default function useInfiniteMyRegistrations() {
+  return useInfiniteQuery<MyRegistrationsResponse, Error>({
+    queryKey: ['myRegistrations'],
+    initialPageParam: 0,
+    queryFn: async ({ pageParam = 0 }) => {
+      const data = await getMyRegistrations(pageParam as number, 5);
+      return data;
+    },
+    getNextPageParam: (lastPage, allPages) => {
+      // API size specification: 5
+      if (
+        !lastPage ||
+        !lastPage.registrations ||
+        lastPage.registrations.length < 5
+      ) {
+        return undefined; // No more pages
+      }
+      return allPages.length; // Next page number (0-indexed)
+    },
+  });
+}

--- a/src/mocks/db/event.db.ts
+++ b/src/mocks/db/event.db.ts
@@ -4,6 +4,104 @@ interface MockEvent extends EventDetailResponse {
   // 필요한 경우 추가 필드 정의
 }
 
+const generatedHostedEvents = Array.from({ length: 20 }).map((_, i) => {
+  const start = new Date('2026-03-01T10:00:00.000Z');
+  start.setDate(start.getDate() + i + 1);
+  const end = new Date(start);
+  end.setHours(end.getHours() + 2);
+
+  const regStart = new Date(start);
+  regStart.setDate(start.getDate() - 7);
+
+  const newId = `generated-event-${i}`;
+
+  return {
+    event: {
+      publicId: newId,
+      title: `무한 스크롤 테스트 생성 모임 ${i + 1}`,
+      description: '테스트용',
+      totalApplicants: Math.floor(i / 2),
+      location: '테스트장소',
+      startsAt: start.toISOString(),
+      endsAt: end.toISOString(),
+      registrationStartsAt: regStart.toISOString(),
+      registrationEndsAt: start.toISOString(),
+      capacity: 10 + i,
+    },
+    creator: {
+      name: '나 (Host)',
+      email: 'me@example.com',
+    },
+    viewer: {
+      status: 'HOST' as const,
+      name: '나 (Host)',
+      waitlistPosition: 0,
+      registrationPublicId: `reg-${newId}`,
+      reservationEmail: 'me@example.com',
+    },
+    capabilities: {
+      shareLink: true,
+      apply: false,
+      wait: false,
+      cancel: false,
+    },
+    guestsPreview: [],
+  };
+});
+
+const generatedJoinedEvents = Array.from({ length: 15 }).map((_, i) => {
+  const isPast = i % 3 === 0;
+  const now = new Date();
+
+  const startAt = new Date(now);
+  startAt.setDate(now.getDate() + (isPast ? -5 : 5 + i));
+  const endAt = new Date(startAt);
+  endAt.setHours(startAt.getHours() + 2);
+
+  const regStart = new Date(startAt);
+  regStart.setDate(startAt.getDate() - 14);
+  const regEnd = new Date(startAt);
+  regEnd.setDate(startAt.getDate() - 2);
+
+  const newId = `reg-mock-${i}`;
+  const status = (
+    i % 4 === 0 ? 'WAITLISTED' : i % 5 === 0 ? 'CANCELED' : 'CONFIRMED'
+  ) as 'CONFIRMED' | 'WAITLISTED' | 'CANCELED';
+
+  return {
+    event: {
+      publicId: newId,
+      title: `참여 테스트 모임 ${i + 1}`,
+      description: '테스트용',
+      totalApplicants: Math.floor(Math.random() * (20 + i)),
+      location: '테스트장소',
+      startsAt: startAt.toISOString(),
+      endsAt: endAt.toISOString(),
+      registrationStartsAt: regStart.toISOString(),
+      registrationEndsAt: regEnd.toISOString(),
+      capacity: 20 + i,
+    },
+    creator: {
+      name: '주최자',
+      email: 'host@example.com',
+    },
+    viewer: {
+      status: status,
+      name: '나',
+      waitlistPosition: i % 4 === 0 ? Math.floor(Math.random() * 5) + 1 : 0,
+      registrationPublicId: `reg-${newId}`,
+      reservationEmail: 'me@example.com',
+    },
+    capabilities: {
+      shareLink: true,
+      apply: false,
+      wait: false,
+      cancel: true,
+    },
+    guestsPreview: [],
+  };
+});
+
 export const eventDB: MockEvent[] = [
   {
     event: {
@@ -181,4 +279,6 @@ export const eventDB: MockEvent[] = [
       },
     ],
   },
+  ...generatedHostedEvents,
+  ...generatedJoinedEvents,
 ];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,10 +1,12 @@
 import { authHandlers } from './handlers/auth';
 import { eventHandlers } from './handlers/event';
+import { registrationHandlers } from './handlers/registrations';
 import { userHandlers } from './handlers/user';
 
 export const handlers = [
   ...authHandlers,
   ...userHandlers,
+  ...registrationHandlers,
   ...eventHandlers,
   // 앞으로 추가될 postHandlers, commentHandlers 등을 여기에 추가합니다.
 ];

--- a/src/mocks/handlers/event.ts
+++ b/src/mocks/handlers/event.ts
@@ -10,13 +10,18 @@ import { path } from '../utils';
 export const eventHandlers = [
   // 1. 내가 생성한/참여한 일정 목록 조회 (GET /events/me)
   // :id 보다 먼저 정의되어야 'me'를 id로 인식하지 않음
-  http.get(path('/events/me'), async () => {
+  http.get(path('/events/me'), async ({ request }) => {
+    const url = new URL(request.url);
+    const cursor = url.searchParams.get('cursor');
+    const size = 5;
+
     await delay(300);
 
     // eventDB에서 내가 참여한(viewer.status가 NONE이 아닌) 이벤트만 필터링하거나
     // 간단히 모든 이벤트를 내 이벤트로 간주하여 반환 (데모 목적)
     const myEvents = eventDB
       // 실제로는 user token을 확인해서 필터링해야 하지만, 여기서는 예시로 일부만 반환하거나 전체 반환
+      .filter((e) => e.viewer.status === 'HOST' || e.viewer.status === 'NONE')
       .map((e) => ({
         publicId: e.event.publicId,
         title: e.event.title,
@@ -28,10 +33,23 @@ export const eventHandlers = [
         totalApplicants: e.event.totalApplicants,
       }));
 
+    // Cursor pagination logic mock
+    let startIndex = 0;
+    if (cursor) {
+      const idx = myEvents.findIndex((e) => e.startsAt === cursor);
+      if (idx !== -1) startIndex = idx + 1; // start from next item
+    }
+
+    const paginatedEvents = myEvents.slice(startIndex, startIndex + size);
+    const hasNext = startIndex + size < myEvents.length;
+    const nextCursor = hasNext
+      ? paginatedEvents[paginatedEvents.length - 1].startsAt
+      : null;
+
     return HttpResponse.json({
-      events: myEvents,
-      nextCursor: null,
-      hasNext: false,
+      events: paginatedEvents,
+      nextCursor,
+      hasNext,
     });
   }),
 

--- a/src/mocks/handlers/registrations.ts
+++ b/src/mocks/handlers/registrations.ts
@@ -1,0 +1,40 @@
+import type { MyRegistrationsResponse } from '@/types/registrations';
+import { http, HttpResponse, delay } from 'msw';
+import { eventDB } from '../db/event.db';
+import { path } from '../utils';
+
+export const registrationHandlers = [
+  // 내가 신청한 일정 조회 (GET /registrations/me)
+  http.get(path('/registrations/me'), async ({ request }) => {
+    const url = new URL(request.url);
+    const page = parseInt(url.searchParams.get('page') || '0', 10);
+    const size = parseInt(url.searchParams.get('size') || '5', 10);
+
+    await delay(300);
+
+    const myRegistrations = eventDB
+      .filter((e) => e.viewer.status !== 'HOST' && e.viewer.status !== 'NONE')
+      .map((e) => ({
+        publicId: e.event.publicId,
+        title: e.event.title,
+        startAt: e.event.startsAt || '',
+        endAt: e.event.endsAt || '',
+        registrationStart: e.event.registrationStartsAt || '',
+        registrationDeadline: e.event.registrationEndsAt || '',
+        capacity: e.event.capacity || 0,
+        registrationCnt: e.event.totalApplicants || 0,
+        status: e.viewer.status as 'CONFIRMED' | 'WAITLISTED' | 'CANCELED',
+        waitingNum: e.viewer.waitlistPosition,
+      }));
+
+    const startIndex = page * size;
+    const paginatedRegistrations = myRegistrations.slice(
+      startIndex,
+      startIndex + size
+    );
+
+    return HttpResponse.json<MyRegistrationsResponse>({
+      registrations: paginatedRegistrations,
+    });
+  }),
+];

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -101,14 +101,14 @@ export default function Home() {
       </div>
 
       {/* 탭 UI 영역 */}
-      <div className="flex border-b mt-4">
+      <div className="flex">
         {['생성한 모임', '참여한 모임'].map((label, idx) => {
           const tabValue = ['hosted', 'joined'][idx] as 'hosted' | 'joined';
           return (
             <button
               key={tabValue}
               onClick={() => setActiveTab(tabValue)}
-              className={`flex-1 py-4 font-bold ${activeTab === tabValue ? 'border-b-2 border-black text-black' : 'text-gray-400'}`}
+              className={`flex-1 py-1 ${activeTab === tabValue ? 'text-xl font-semibold border-b-2 border-black text-black' : 'text-md border-b-1 border-[#767676] text-[#767676]'}`}
             >
               {label}
             </button>

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,6 +1,7 @@
 import AuthBox from '@/components/AuthBox';
 import Dashboard from '@/components/Dashboard';
 import LoadingSkeleton from '@/components/LoadingSkeleton';
+import NewEventButton from '@/components/NewEventButton';
 import useAuth from '@/hooks/useAuth';
 import useInfiniteMyEvents from '@/hooks/useInfiniteMyEvents';
 import useInfiniteMyRegistrations from '@/hooks/useInfiniteMyRegistrations';
@@ -93,7 +94,12 @@ export default function Home() {
     joinedData?.pages.flatMap((page) => page?.registrations || []) || [];
 
   return (
-    <div className="flex flex-col flex-1 w-full max-w-2xl mx-auto px-4 py-4 gap-6">
+    <div className="flex flex-col flex-1 w-full max-w-2xl mx-auto px-4 py-4 gap-4">
+      {/* 새 일정 만들기 버튼 */}
+      <div className="flex items-center justify-end mb-4">
+        <NewEventButton />
+      </div>
+
       {/* 탭 UI 영역 */}
       <div className="flex border-b mt-4">
         {['생성한 모임', '참여한 모임'].map((label, idx) => {
@@ -132,7 +138,7 @@ export default function Home() {
               ? events.length > 0
               : registrations.length > 0
           ) ? (
-          <p className="text-gray-400 text-sm mt-4 pb-10">마지막 일정입니다.</p>
+          <p className="body-small text-muted-foreground">마지막 일정입니다.</p>
         ) : null}
       </div>
     </div>

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,25 +1,55 @@
-import getMyEvents from '@/api/events/me';
 import AuthBox from '@/components/AuthBox';
 import Dashboard from '@/components/Dashboard';
+import LoadingSkeleton from '@/components/LoadingSkeleton';
 import useAuth from '@/hooks/useAuth';
-import type { MyEvent } from '@/types/events';
+import useInfiniteMyEvents from '@/hooks/useInfiniteMyEvents';
+import useInfiniteMyRegistrations from '@/hooks/useInfiniteMyRegistrations';
+import { Loader2 } from 'lucide-react';
 import { useEffect, useState } from 'react';
+import { useInView } from 'react-intersection-observer';
 
 export default function Home() {
   const { isLoggedIn } = useAuth();
-  const [events, setEvents] = useState<MyEvent[]>([]);
+  const [activeTab, setActiveTab] = useState<'hosted' | 'joined'>('hosted');
+
+  // queries
+  const {
+    data: hostedData,
+    fetchNextPage: fetchNextHosted,
+    hasNextPage: hasNextHosted,
+    isFetchingNextPage: isFetchingHosted,
+    isLoading: isLoadingHosted,
+  } = useInfiniteMyEvents();
+
+  const {
+    data: joinedData,
+    fetchNextPage: fetchNextJoined,
+    hasNextPage: hasNextJoined,
+    isFetchingNextPage: isFetchingJoined,
+    isLoading: isLoadingJoined,
+  } = useInfiniteMyRegistrations();
+
+  // 바닥 감지 훅
+  const { ref, inView } = useInView();
 
   useEffect(() => {
-    if (!isLoggedIn) return;
-
-    getMyEvents()
-      .then((res) => {
-        setEvents(res.data?.events || []);
-      })
-      .catch((err) => {
-        console.error(err);
-      });
-  }, [isLoggedIn]);
+    if (inView) {
+      if (activeTab === 'hosted' && hasNextHosted && !isFetchingHosted) {
+        fetchNextHosted();
+      } else if (activeTab === 'joined' && hasNextJoined && !isFetchingJoined) {
+        fetchNextJoined();
+      }
+    }
+  }, [
+    inView,
+    activeTab,
+    hasNextHosted,
+    isFetchingHosted,
+    fetchNextHosted,
+    hasNextJoined,
+    isFetchingJoined,
+    fetchNextJoined,
+  ]);
 
   // if not logged in, show the landing page
   if (!isLoggedIn) {
@@ -42,10 +72,69 @@ export default function Home() {
     );
   }
 
-  // otherwise, show the dashboard with event cards
+  // 로딩 상태 처리: 데이터가 없는 첫 로딩 시에만 스켈레톤 노출
+  const isInitialLoading =
+    (activeTab === 'hosted' && isLoadingHosted) ||
+    (activeTab === 'joined' && isLoadingJoined);
+
+  if (isInitialLoading) {
+    return (
+      <div className="flex flex-col flex-1 w-full max-w-2xl mx-auto px-4 py-4 gap-6">
+        <LoadingSkeleton
+          loadingTitle="불러오는 중..."
+          message="일정 정보를 가져오고 있습니다."
+        />
+      </div>
+    );
+  }
+
+  const events = hostedData?.pages.flatMap((page) => page?.events || []) || [];
+  const registrations =
+    joinedData?.pages.flatMap((page) => page?.registrations || []) || [];
+
   return (
-    <div className="px-4 py-4 flex-1 flex justify-center">
-      <Dashboard events={events} />
+    <div className="flex flex-col flex-1 w-full max-w-2xl mx-auto px-4 py-4 gap-6">
+      {/* 탭 UI 영역 */}
+      <div className="flex border-b mt-4">
+        {['생성한 모임', '참여한 모임'].map((label, idx) => {
+          const tabValue = ['hosted', 'joined'][idx] as 'hosted' | 'joined';
+          return (
+            <button
+              key={tabValue}
+              onClick={() => setActiveTab(tabValue)}
+              className={`flex-1 py-4 font-bold ${activeTab === tabValue ? 'border-b-2 border-black text-black' : 'text-gray-400'}`}
+            >
+              {label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 이벤트/신청내역 목록 렌더링 */}
+      <Dashboard
+        events={events}
+        registrations={registrations}
+        type={activeTab}
+      />
+
+      {/* 무한 스크롤 트리거 및 로딩 인디케이터 컨테이너 */}
+      <div ref={ref} className="py-8 flex justify-center mt-auto">
+        {(activeTab === 'hosted' && isFetchingHosted) ||
+        (activeTab === 'joined' && isFetchingJoined) ? (
+          <Loader2 className="animate-spin h-8 w-8 text-gray-400" />
+        ) : (activeTab === 'hosted' && hasNextHosted) ||
+          (activeTab === 'joined' && hasNextJoined) ? (
+          <p className="text-gray-400 text-sm">
+            목록을 더 불러오고 있습니다...
+          </p>
+        ) : (
+            activeTab === 'hosted'
+              ? events.length > 0
+              : registrations.length > 0
+          ) ? (
+          <p className="text-gray-400 text-sm mt-4 pb-10">마지막 일정입니다.</p>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -101,14 +101,14 @@ export default function Home() {
       </div>
 
       {/* 탭 UI 영역 */}
-      <div className="flex">
+      <div className="border-b-1 border-border sticky top-16 bg-white z-10 flex pt-2 -mx-4 px-4">
         {['생성한 모임', '참여한 모임'].map((label, idx) => {
           const tabValue = ['hosted', 'joined'][idx] as 'hosted' | 'joined';
           return (
             <button
               key={tabValue}
               onClick={() => setActiveTab(tabValue)}
-              className={`flex-1 py-1 ${activeTab === tabValue ? 'text-xl font-semibold border-b-2 border-black text-black' : 'text-md border-b-1 border-[#767676] text-[#767676]'}`}
+              className={`flex-1 py-1 ${activeTab === tabValue ? 'text-xl font-semibold border-b-2 border-black text-black' : 'text-md text-[#767676]'}`}
             >
               {label}
             </button>

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -78,6 +78,8 @@ export interface UpdateEventResponse extends Event {
 
 export interface MyEventsResponse {
   events: MyEvent[];
+  nextCursor?: string;
+  hasNext: boolean;
 }
 
 export interface MyEvent {

--- a/src/types/registrations.ts
+++ b/src/types/registrations.ts
@@ -1,4 +1,4 @@
-import type { Event, EventId, GuestStatus } from '@/types/schemas';
+import type { GuestStatus } from '@/types/schemas';
 
 // ---------- GET /me ----------
 
@@ -6,11 +6,17 @@ export interface MyRegistrationsResponse {
   registrations: MyRegistration[];
 }
 
-interface MyRegistration extends Event {
-  publicId: EventId;
-  totalApplicants: number;
-  status: GuestStatus;
-  waitlistPosition?: number;
+export interface MyRegistration {
+  publicId: string;
+  title: string;
+  startAt?: string;
+  endAt?: string;
+  registrationStart: string;
+  registrationDeadline: string;
+  capacity: number;
+  registrationCnt: number;
+  status: 'CONFIRMED' | 'WAITLISTED' | 'CANCELED';
+  waitingNum?: number;
 }
 
 // ---------- GET /:id ----------


### PR DESCRIPTION
### 📝 작업 내용

- 랜딩페이지에서 생성한 일정, 참여한 일정을 탭 ui로 선택할 수 있게 합니다.
- 참여한 일정을 받아오는 api를 추가합니다.
- 생성한 일정, 참여한 일정에 무한스크롤을 추가합니다.
- `mocks`를 수정하여, 이제 `event.db`의 이벤트의 `viewer.status`를 기반으로 생성/참여한 일정을 구분해서 보여줍니다.(개발 편의상 `NONE` 인 경우 생성한 일정에서 보여지게 설정했습니다.)
- 조건부로 생성되는 스크롤바 때문에 ui에 깜빡임이 생기는 현상을 방지하기 위해 `App.css`에 `scrollbar-gutter: stable`를 추가했습니다.

### 📸 스크린샷 (선택)

<img width="1937" height="1132" alt="image" src="https://github.com/user-attachments/assets/b79d9f99-5f67-47e8-a063-8f0f1cc80527" />


### 🚀 리뷰 요구사항 (선택)

- 피그마에 따라 탭ui를 **생성한 모임**과 **참여한 모임** 이라는 문구로 설정했는데, 페이지 전체적으로 **모임**과 **일정**이 혼용되고 있습니다. 한 쪽으로 통일하는 것이 좋아 보이는데, 어느 쪽을 선호하시나요?
- 신청한 모임 페이지네이션이 한 번에 5개로 고정되는 듯 하여, 참여한 모임에서도 20개가 아닌 5개 씩 페이지네이션 되게 만들었는데, 참여한 모임에서 만이라도 20개로 늘리는게 좋을까요?
- 참여한 모임 페이지네이션은 꼼수로 구현한 것이라, 추후 백엔드와 함께 리팩토링이 필요할 것 같습니다.