### PR TITLE
⚡️ Memoise default values in event forms

### DIFF
--- a/src/routes/EventEdit.tsx
+++ b/src/routes/EventEdit.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import useAuthStore from '@/hooks/useAuthStore';
 import useEventDetail from '@/hooks/useEventDetail';
 import { AlertCircle } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { toast } from 'sonner';
 
@@ -33,6 +33,29 @@ export default function EventEdit() {
       });
     }
   }, [id, handleFetchDetail, navigate]);
+
+  const defaultValues = useMemo(() => {
+    if (!data) return undefined;
+    const { event } = data;
+    const now = new Date();
+
+    return {
+      title: event.title,
+      capacity: event.capacity,
+      isFromNow: false,
+      isBounded: !!event.endsAt,
+      regiStartDate: event.registrationStartsAt
+        ? new Date(event.registrationStartsAt)
+        : now,
+      regiEndDate: event.registrationEndsAt
+        ? new Date(event.registrationEndsAt)
+        : new Date(now.getTime() + 72 * 60 * 60 * 1000),
+      eventStartDate: event.startsAt ? new Date(event.startsAt) : now,
+      eventEndDate: event.endsAt ? new Date(event.endsAt) : undefined,
+      location: event.location || '',
+      description: event.description || '',
+    };
+  }, [data]);
 
   if (isDeleted || !id) {
     return (
@@ -63,27 +86,6 @@ export default function EventEdit() {
       />
     );
   }
-
-  const { event } = data;
-
-  const now = new Date();
-
-  const defaultValues: FormValues = {
-    title: event.title,
-    capacity: event.capacity,
-    isFromNow: false,
-    isBounded: !!event.endsAt,
-    regiStartDate: event.registrationStartsAt
-      ? new Date(event.registrationStartsAt)
-      : now,
-    regiEndDate: event.registrationEndsAt
-      ? new Date(event.registrationEndsAt)
-      : new Date(now.getTime() + 72 * 60 * 60 * 1000),
-    eventStartDate: event.startsAt ? new Date(event.startsAt) : now,
-    eventEndDate: event.endsAt ? new Date(event.endsAt) : undefined,
-    location: event.location || '',
-    description: event.description || '',
-  };
 
   const handleSubmit = async (formData: FormValues) => {
     if (!user) {
@@ -127,7 +129,7 @@ export default function EventEdit() {
   return (
     <EventForm
       pageTitle="일정 수정하기"
-      defaultValues={defaultValues}
+      defaultValues={defaultValues!}
       onSubmit={handleSubmit}
       loading={isSubmitting}
       onBack={() => navigate(-1)}

--- a/src/routes/NewEvent.tsx
+++ b/src/routes/NewEvent.tsx
@@ -2,6 +2,7 @@ import { EventForm } from '@/components/EventForm';
 import type { FormValues } from '@/components/EventForm';
 import useAuthStore from '@/hooks/useAuthStore';
 import useEvent from '@/hooks/useEvent';
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 
@@ -10,24 +11,26 @@ export default function NewEvent() {
   const user = useAuthStore((state) => state.user);
   const { createEvent, loading } = useEvent();
 
-  const now = new Date();
-  const initialRegiEndDate = new Date(now.getTime() + 72 * 60 * 60 * 1000); // 3 days later
-  const initialEventStartDate = new Date(
-    initialRegiEndDate.getTime() + 24 * 60 * 60 * 1000
-  );
+  const defaultValues = useMemo(() => {
+    const now = new Date();
+    const initialRegiEndDate = new Date(now.getTime() + 72 * 60 * 60 * 1000); // 3 days later
+    const initialEventStartDate = new Date(
+      initialRegiEndDate.getTime() + 24 * 60 * 60 * 1000
+    );
 
-  const defaultValues: FormValues = {
-    title: '',
-    capacity: 4,
-    isFromNow: true,
-    isBounded: false,
-    regiStartDate: now,
-    regiEndDate: initialRegiEndDate,
-    eventStartDate: initialEventStartDate,
-    eventEndDate: undefined,
-    location: '',
-    description: '',
-  };
+    return {
+      title: '',
+      capacity: 4,
+      isFromNow: true,
+      isBounded: false,
+      regiStartDate: now,
+      regiEndDate: initialRegiEndDate,
+      eventStartDate: initialEventStartDate,
+      eventEndDate: undefined,
+      location: '',
+      description: '',
+    };
+  }, []);
 
   const onSubmit = async (data: FormValues) => {
     if (!user) {


### PR DESCRIPTION
### 📝 작업 내용

- 일정 생성에 실패하면 모달과 함께 입력했던 값이 모두 날아간다는 문제가 있었습니다.
- 문제의 원인이 렌더링이 일어나는 타이밍에 있다는 진단이 있었고, 이 가설에 따라 이벤트 폼 기본값을 기억화하여 재렌더링을 방지하였습니다.
  - 생성 페이지에서는 초기 값이 변할 필요가 없으므로 빈 의존성 배열(`[]`)을 사용하여 메모이제이션했습니다.
  - 수정 페이지에서는 서버에서 가져온 `data`가 변경될 때만 초기값이 갱신되도록 `[data]`를 의존성 배열에 추가하고, Hook의 규칙을 지키기 위해 조건부 렌더링(Loading/Error) 상단으로 위치를 조정했습니다.
- 로컬 동작은 확인했는데 항상 서버와 연결되었을 때 무슨 일이 일어날지 모르기에… 확신은 없습니다.

### 🔍 Gemini says

1. **매 렌더링마다 새로운 객체 생성**
  `NewEvent.tsx`와 `EventEdit.tsx` 부모 컴포넌트에서 `defaultValues` 객체를 컴포넌트 바디 안에서 매번 새로 생성하고 있었습니다. 특히 `new Date()`를 호출하여 매 초마다 미세하게 값이 바뀌는 객체가 전달되었습니다.

2. **`EventForm`의 `useEffect` 트리거**
  `EventForm.tsx` 내부에서는 `defaultValues`가 변경될 때마다 `react-hook-form`의 `reset(defaultValues)`를 호출하는 `useEffect`가 있었습니다.

3. **의도치 않은 폼 초기화**
  사용자가 "저장" 버튼을 누르면 API 요청을 위해 loading 상태가 변하게 되고, 이로 인해 부모 컴포넌트가 재렌더링됩니다. 이때 `defaultValues`가 새로운 참조값으로 생성되면서 `EventForm`의 `reset`이 실행되어 사용자가 입력한 값들이 서버 응답(에러 모달 등)을 보기도 전에 사라지는 현상이 발생했습니다.

