### PR TITLE
🦺 Update event date/time validation

### DIFF
--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -36,7 +36,7 @@ const baseSchema = z.object({
     .trim()
     .min(1, '제목을 입력해 주세요.')
     .max(20, '제목은 20자 이내로 입력해 주세요.'),
-  capacity: z.number().min(1, '정원은 1 이상이어야 합니다.'),
+  capacity: z.number().min(1, '정원은 1명 이상이어야 합니다.'),
   isFromNow: z.boolean(),
   isBounded: z.boolean(),
   regiStartDate: z.date(),
@@ -57,7 +57,7 @@ function createFormSchema(mode: 'create' | 'edit') {
     if (mode === 'create' && data.regiEndDate <= new Date()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: '신청 마감 시간은 현재 시간 이후여야 합니다.',
+        message: '신청 마감은 현재 이후여야 합니다.',
         path: ['regiEndDate'],
       });
     }
@@ -66,7 +66,7 @@ function createFormSchema(mode: 'create' | 'edit') {
     if (!data.isFromNow && data.regiStartDate >= data.regiEndDate) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: '신청 마감 시간이 신청 시작 시간보다 빠를 수 없습니다.',
+        message: '신청 마감은 신청 시작 이후여야 합니다.',
         path: ['regiEndDate'],
       });
     }
@@ -79,7 +79,7 @@ function createFormSchema(mode: 'create' | 'edit') {
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: '모임 종료 시간이 모임 시작 시간보다 빠를 수 없습니다.',
+        message: '모임 종료는 모임 시작 이후여야 합니다.',
         path: ['eventEndDate'],
       });
     }

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -26,34 +26,35 @@ import { Textarea } from '@/components/ui/textarea';
 import { formatEventDate } from '@/utils/date';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2 } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-const formSchema = z
-  .object({
-    title: z
-      .string()
-      .trim()
-      .min(1, '제목을 입력해 주세요.')
-      .max(20, '제목은 20자 이내로 입력해 주세요.'),
-    capacity: z.number().min(1, '정원은 1 이상이어야 합니다.'),
-    isFromNow: z.boolean(),
-    isBounded: z.boolean(),
-    regiStartDate: z.date(),
-    regiEndDate: z.date(),
-    eventStartDate: z.date(),
-    eventEndDate: z.date().optional(),
-    location: z
-      .string()
-      .trim()
-      .max(20, '장소는 20자 이내로 입력해 주세요.')
-      .optional(),
-    description: z.string().trim().optional(),
-  })
-  .superRefine((data, ctx) => {
-    // 1. 신청 마감 시간은 현재 시간 이후여야 함
-    if (data.regiEndDate <= new Date()) {
+const baseSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, '제목을 입력해 주세요.')
+    .max(20, '제목은 20자 이내로 입력해 주세요.'),
+  capacity: z.number().min(1, '정원은 1 이상이어야 합니다.'),
+  isFromNow: z.boolean(),
+  isBounded: z.boolean(),
+  regiStartDate: z.date(),
+  regiEndDate: z.date(),
+  eventStartDate: z.date(),
+  eventEndDate: z.date().optional(),
+  location: z
+    .string()
+    .trim()
+    .max(20, '장소는 20자 이내로 입력해 주세요.')
+    .optional(),
+  description: z.string().trim().optional(),
+});
+
+function createFormSchema(mode: 'create' | 'edit') {
+  return baseSchema.superRefine((data, ctx) => {
+    // 1. [생성 전용] 신청 마감 시간은 현재 시간 이후여야 함
+    if (mode === 'create' && data.regiEndDate <= new Date()) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: '신청 마감 시간은 현재 시간 이후여야 합니다.',
@@ -70,11 +71,11 @@ const formSchema = z
       });
     }
 
-    // 3. 모임 기간 검증 (종료 시간이 있을 때만)
+    // 3. 모임 기간 검증(종료 시간이 있을 때만)
     if (
       data.isBounded &&
       data.eventEndDate &&
-      data.eventStartDate >= data.eventEndDate
+      data.eventStartDate > data.eventEndDate
     ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -82,9 +83,19 @@ const formSchema = z
         path: ['eventEndDate'],
       });
     }
-  });
 
-export type FormValues = z.infer<typeof formSchema>;
+    // 4. 신청 마감 ≤ 모임 시작 검증 (불변 규칙)
+    if (data.regiEndDate > data.eventStartDate) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: '신청 마감은 모임 시작 이전이어야 합니다.',
+        path: ['regiEndDate'],
+      });
+    }
+  });
+}
+
+export type FormValues = z.infer<typeof baseSchema>;
 
 interface EventFormProps {
   pageTitle: string;
@@ -95,6 +106,8 @@ interface EventFormProps {
   submitButtonText?: string;
   saveDialogTitle?: string;
   saveDialogDescription?: string;
+  mode?: 'create' | 'edit';
+  isRegistrationClosed?: boolean;
 }
 
 export function EventForm({
@@ -106,12 +119,16 @@ export function EventForm({
   submitButtonText = '저장',
   saveDialogTitle = '일정을 저장하시겠습니까?',
   saveDialogDescription = '참여자가 생기는 경우, 기본 정보를 수정하기 어려울 수 있습니다.',
+  mode = 'create',
+  isRegistrationClosed = false,
 }: EventFormProps) {
   const [step, setStep] = useState<1 | 2>(1);
   const [showSaveDialog, setShowSaveDialog] = useState(false);
 
+  const schema = useMemo(() => createFormSchema(mode), [mode]);
+
   const form = useForm<FormValues>({
-    resolver: zodResolver(formSchema),
+    resolver: zodResolver(schema),
     defaultValues,
     mode: 'onChange',
   });
@@ -139,8 +156,8 @@ export function EventForm({
     const isValidStep1 = await trigger([
       'title',
       'capacity',
-      'regiStartDate',
-      'regiEndDate',
+      'eventStartDate',
+      'eventEndDate',
     ]);
 
     if (isValidStep1) {
@@ -148,8 +165,8 @@ export function EventForm({
       const step1Errors = [
         errors.title,
         errors.capacity,
-        errors.regiStartDate,
-        errors.regiEndDate,
+        errors.eventStartDate,
+        errors.eventEndDate,
       ];
 
       if (step1Errors.every((e) => !e)) {
@@ -159,15 +176,6 @@ export function EventForm({
   };
 
   const onSubmit = async (data: FormValues) => {
-    // Step 2 Cross-validation
-    if (data.regiEndDate > data.eventStartDate) {
-      form.setError('regiEndDate', {
-        type: 'manual',
-        message: '모임 시작 시간이 신청 마감 시간보다 빠를 수 없습니다.',
-      });
-      return;
-    }
-
     await handleFormSubmit(data);
   };
 
@@ -308,11 +316,6 @@ export function EventForm({
                     {errors.eventStartDate && (
                       <p className={errorTextStyle}>
                         {errors.eventStartDate.message}
-                      </p>
-                    )}
-                    {!errors.eventStartDate && errors.regiEndDate && (
-                      <p className={errorTextStyle}>
-                        {errors.regiEndDate.message}
                       </p>
                     )}
                   </Field>
@@ -463,7 +466,7 @@ export function EventForm({
                             value={field.value}
                             onChange={field.onChange}
                             placeholder="언제 시작할까요?"
-                            disabled={isFromNow}
+                            disabled={isFromNow || isRegistrationClosed}
                           />
                         )}
                       />
@@ -489,21 +492,6 @@ export function EventForm({
                           value={field.value}
                           onChange={(date) => {
                             field.onChange(date);
-                            if (date) {
-                              const newEventStart = new Date(
-                                date.getTime() + 24 * 60 * 60 * 1000
-                              );
-                              setValue('eventStartDate', newEventStart);
-
-                              if (isBounded) {
-                                setValue(
-                                  'eventEndDate',
-                                  new Date(
-                                    newEventStart.getTime() + 60 * 60 * 1000
-                                  )
-                                );
-                              }
-                            }
                           }}
                           placeholder="언제 마감할까요?"
                         />
@@ -601,20 +589,8 @@ export function EventForm({
               disabled={loading || isSubmitting}
               onClick={async () => {
                 const isSchemaValid = await trigger();
-                const values = getValues();
-                let isManualValid = true;
 
-                // Cross-validation: 신청 마감 vs 모임 시작
-                if (values.regiEndDate > values.eventStartDate) {
-                  form.setError('regiEndDate', {
-                    type: 'manual',
-                    message:
-                      '모임 시작 시간이 신청 마감 시간보다 빠를 수 없습니다.',
-                  });
-                  isManualValid = false;
-                }
-
-                if (isSchemaValid && isManualValid) {
+                if (isSchemaValid) {
                   setShowSaveDialog(true);
                 }
               }}

--- a/src/routes/EventEdit.tsx
+++ b/src/routes/EventEdit.tsx
@@ -68,6 +68,10 @@ export default function EventEdit() {
 
   const now = new Date();
 
+  const isRegistrationClosed =
+    !!event.registrationEndsAt &&
+    new Date(event.registrationEndsAt) <= now;
+
   const defaultValues: FormValues = {
     title: event.title,
     capacity: event.capacity,
@@ -134,6 +138,8 @@ export default function EventEdit() {
       submitButtonText="수정하기"
       saveDialogTitle="일정을 수정하시겠습니까?"
       saveDialogDescription="참여자가 있는 경우, 모임 정보가 변경되면 혼선이 있을 수 있습니다."
+      mode="edit"
+      isRegistrationClosed={isRegistrationClosed}
     />
   );
 }

--- a/src/routes/EventEdit.tsx
+++ b/src/routes/EventEdit.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import useAuthStore from '@/hooks/useAuthStore';
 import useEventDetail from '@/hooks/useEventDetail';
 import { AlertCircle } from 'lucide-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { toast } from 'sonner';
 
@@ -33,6 +33,36 @@ export default function EventEdit() {
       });
     }
   }, [id, handleFetchDetail, navigate]);
+
+  const event = data?.event;
+
+  const isRegistrationClosed = useMemo(
+    () =>
+      !!event?.registrationEndsAt &&
+      new Date(event.registrationEndsAt) <= new Date(),
+    [event]
+  );
+
+  const defaultValues = useMemo<FormValues>(() => {
+    if (!event) return null as unknown as FormValues;
+    const now = new Date();
+    return {
+      title: event.title,
+      capacity: event.capacity,
+      isFromNow: false,
+      isBounded: !!event.endsAt,
+      regiStartDate: event.registrationStartsAt
+        ? new Date(event.registrationStartsAt)
+        : now,
+      regiEndDate: event.registrationEndsAt
+        ? new Date(event.registrationEndsAt)
+        : new Date(now.getTime() + 72 * 60 * 60 * 1000),
+      eventStartDate: event.startsAt ? new Date(event.startsAt) : now,
+      eventEndDate: event.endsAt ? new Date(event.endsAt) : undefined,
+      location: event.location || '',
+      description: event.description || '',
+    };
+  }, [event]);
 
   if (isDeleted || !id) {
     return (
@@ -63,30 +93,6 @@ export default function EventEdit() {
       />
     );
   }
-
-  const { event } = data;
-
-  const now = new Date();
-
-  const isRegistrationClosed =
-    !!event.registrationEndsAt && new Date(event.registrationEndsAt) <= now;
-
-  const defaultValues: FormValues = {
-    title: event.title,
-    capacity: event.capacity,
-    isFromNow: false,
-    isBounded: !!event.endsAt,
-    regiStartDate: event.registrationStartsAt
-      ? new Date(event.registrationStartsAt)
-      : now,
-    regiEndDate: event.registrationEndsAt
-      ? new Date(event.registrationEndsAt)
-      : new Date(now.getTime() + 72 * 60 * 60 * 1000),
-    eventStartDate: event.startsAt ? new Date(event.startsAt) : now,
-    eventEndDate: event.endsAt ? new Date(event.endsAt) : undefined,
-    location: event.location || '',
-    description: event.description || '',
-  };
 
   const handleSubmit = async (formData: FormValues) => {
     if (!user) {

--- a/src/routes/EventEdit.tsx
+++ b/src/routes/EventEdit.tsx
@@ -110,7 +110,7 @@ export default function EventEdit() {
         capacity: formData.capacity,
         waitlistEnabled: true,
         registrationStartsAt: formData.isFromNow
-          ? new Date().toISOString()
+          ? undefined
           : formData.regiStartDate.toISOString(),
         registrationEndsAt: formData.regiEndDate.toISOString(),
       };

--- a/src/routes/EventEdit.tsx
+++ b/src/routes/EventEdit.tsx
@@ -69,8 +69,7 @@ export default function EventEdit() {
   const now = new Date();
 
   const isRegistrationClosed =
-    !!event.registrationEndsAt &&
-    new Date(event.registrationEndsAt) <= now;
+    !!event.registrationEndsAt && new Date(event.registrationEndsAt) <= now;
 
   const defaultValues: FormValues = {
     title: event.title,
@@ -137,7 +136,7 @@ export default function EventEdit() {
       onBack={() => navigate(-1)}
       submitButtonText="수정하기"
       saveDialogTitle="일정을 수정하시겠습니까?"
-      saveDialogDescription="참여자가 있는 경우, 모임 정보가 변경되면 혼선이 있을 수 있습니다."
+      saveDialogDescription="바뀐 내용은 신청자에게 자동으로 전달되지 않습니다. 중요한 수정사항은 직접 안내해 주세요."
       mode="edit"
       isRegistrationClosed={isRegistrationClosed}
     />

--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -136,10 +136,12 @@ export default function EventMain() {
 
   const getRegistrationStatus = (event: DetailedEvent) => {
     const now = new Date();
-    const startDate = new Date(event.registrationStartsAt);
+    const startDate = event.registrationStartsAt
+      ? new Date(event.registrationStartsAt)
+      : undefined;
     const endDate = new Date(event.registrationEndsAt);
 
-    if (now < startDate) return '모집 전';
+    if (startDate && now < startDate) return '모집 전';
     if (endDate <= now) return '모집 종료';
     return '모집 중';
   };

--- a/src/routes/NewEvent.tsx
+++ b/src/routes/NewEvent.tsx
@@ -69,7 +69,7 @@ export default function NewEvent() {
       onBack={() => navigate(-1)}
       submitButtonText="저장"
       saveDialogTitle="일정을 저장하시겠습니까?"
-      saveDialogDescription="참여자가 생기는 경우, 기본 정보를 수정하기 어려울 수 있습니다."
+      saveDialogDescription="일정을 저장한 이후에도 수정 및 삭제가 가능합니다."
       mode="create"
     />
   );

--- a/src/routes/NewEvent.tsx
+++ b/src/routes/NewEvent.tsx
@@ -2,6 +2,7 @@ import { EventForm } from '@/components/EventForm';
 import type { FormValues } from '@/components/EventForm';
 import useAuthStore from '@/hooks/useAuthStore';
 import useEvent from '@/hooks/useEvent';
+import { useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import { toast } from 'sonner';
 
@@ -10,24 +11,22 @@ export default function NewEvent() {
   const user = useAuthStore((state) => state.user);
   const { createEvent, loading } = useEvent();
 
-  const now = new Date();
-  const initialRegiEndDate = new Date(now.getTime() + 72 * 60 * 60 * 1000); // 3 days later
-  const initialEventStartDate = new Date(
-    initialRegiEndDate.getTime() + 24 * 60 * 60 * 1000
-  );
-
-  const defaultValues: FormValues = {
-    title: '',
-    capacity: 4,
-    isFromNow: true,
-    isBounded: false,
-    regiStartDate: now,
-    regiEndDate: initialRegiEndDate,
-    eventStartDate: initialEventStartDate,
-    eventEndDate: undefined,
-    location: '',
-    description: '',
-  };
+  const defaultValues = useMemo<FormValues>(() => {
+    const now = new Date();
+    const regiEndDate = new Date(now.getTime() + 72 * 60 * 60 * 1000); // 3 days later
+    return {
+      title: '',
+      capacity: 4,
+      isFromNow: true,
+      isBounded: false,
+      regiStartDate: now,
+      regiEndDate,
+      eventStartDate: new Date(regiEndDate.getTime() + 24 * 60 * 60 * 1000),
+      eventEndDate: undefined,
+      location: '',
+      description: '',
+    };
+  }, []);
 
   const onSubmit = async (data: FormValues) => {
     if (!user) {

--- a/src/routes/NewEvent.tsx
+++ b/src/routes/NewEvent.tsx
@@ -70,6 +70,7 @@ export default function NewEvent() {
       submitButtonText="저장"
       saveDialogTitle="일정을 저장하시겠습니까?"
       saveDialogDescription="참여자가 생기는 경우, 기본 정보를 수정하기 어려울 수 있습니다."
+      mode="create"
     />
   );
 }

--- a/src/routes/NewEvent.tsx
+++ b/src/routes/NewEvent.tsx
@@ -47,7 +47,7 @@ export default function NewEvent() {
       capacity: data.capacity,
       waitlistEnabled: true,
       registrationStartsAt: data.isFromNow
-        ? new Date().toISOString()
+        ? undefined
         : data.regiStartDate.toISOString(),
       registrationEndsAt: data.regiEndDate.toISOString(),
     };

--- a/src/types/schemas.ts
+++ b/src/types/schemas.ts
@@ -17,7 +17,7 @@ export interface Event {
   startsAt?: string;
   endsAt?: string;
   capacity: number;
-  registrationStartsAt: string;
+  registrationStartsAt?: string;
   registrationEndsAt: string;
 }
 


### PR DESCRIPTION
## 📝 작업 내용

### 일정 검증 로직 업데이트
- 3월 14일 회의에서 결정된 정책에 맞추어 일정 검증 로직을 고쳤습니다.
- '지금부터 시작하기' 옵션이 켜져 있으면 페이로드의 `registrationStartsAt` 필드를 비우도록 했습니다.

### 의도치 않은 폼 초기화 해결 시도
- 일정 생성에 실패하면 모달과 함께 입력했던 값이 모두 날아간다는 문제가 있었습니다.
- 문제의 원인이 렌더링이 일어나는 타이밍에 있다는 진단이 있었고, 이 가설에 따라 이벤트 폼 기본값을 기억화하여 재렌더링을 방지하였습니다.
  - `NewEvent`: `useMemo([], [])` → 마운트 시 1회만 생성
  - `EventEdit`: `useMemo([event])` → 서버 데이터 변경 시에만 재생성


## 🚀 리뷰 요구사항

- 일정 검증 로직 관련해서 직접 검토도 하고 AI에게도 여러 차례 검토를 부탁했었는데, 그럼에도 놓친 부분이 있을지도 모르겠습니다. 혹시 검증 로직에서 빠진 부분이 보이면 수정 요청해 주시거나, 수정을 부탁드립니다.
- 우선 `defaultValues`의 재렌더링이 문제라는 진단에 따라 이 부분을 수정했고 로컬에서 잘 작동하는 것도 확인했는데, 실제 웹에서도 잘 돌아갈지 모르겠네요. 우선 해봐야 알 것 같습니다… 리뷰에 참고가 될까 하여 제미나이가 지적한 폼 초기화 문제의 원인을 아래에 부칩니다.


## 🔍 Gemini says

1. **매 렌더링마다 새로운 객체 생성**
  `NewEvent.tsx`와 `EventEdit.tsx` 부모 컴포넌트에서 `defaultValues` 객체를 컴포넌트 바디 안에서 매번 새로 생성하고 있었습니다. 특히 `new Date()`를 호출하여 매 초마다 미세하게 값이 바뀌는 객체가 전달되었습니다.

2. **`EventForm`의 `useEffect` 트리거**
  `EventForm.tsx` 내부에서는 `defaultValues`가 변경될 때마다 `react-hook-form`의 `reset(defaultValues)`를 호출하는 `useEffect`가 있었습니다.

3. **의도치 않은 폼 초기화**
  사용자가 "저장" 버튼을 누르면 API 요청을 위해 loading 상태가 변하게 되고, 이로 인해 부모 컴포넌트가 재렌더링됩니다. 이때 `defaultValues`가 새로운 참조값으로 생성되면서 `EventForm`의 `reset`이 실행되어 사용자가 입력한 값들이 서버 응답(에러 모달 등)을 보기도 전에 사라지는 현상이 발생했습니다.
