### PR TITLE
🐛 Fix header login redirect logic

### DIFF
--- a/src/components/AuthBox.tsx
+++ b/src/components/AuthBox.tsx
@@ -1,6 +1,5 @@
 import { Button } from '@/components/ui/button';
 import { GOOGLE_AUTH_URL } from '@/constants/auth';
-import useAuthStore from '@/hooks/useAuthStore';
 import { Link } from 'react-router';
 
 function Separator() {
@@ -81,21 +80,12 @@ function ContinueWithGoogle() {
 type AuthMode = 'sign-up' | 'login';
 
 export default function AuthBox({ mode }: { mode: AuthMode }) {
-  const setRedirectUrl = useAuthStore((state) => state.setRedirectUrl);
   return (
     <div className="flex flex-col gap-6 items-center justify-center">
       <span className="body-base text-center">
         소셜 계정으로 간편 {mode === 'sign-up' ? '회원가입' : '로그인'}
       </span>
-      <a
-        href={GOOGLE_AUTH_URL}
-        aria-label="Google로 회원가입"
-        onClick={() => {
-          if (!useAuthStore.getState().redirectUrl) {
-            setRedirectUrl(location.pathname + location.search);
-          }
-        }}
-      >
+      <a href={GOOGLE_AUTH_URL} aria-label="Google로 회원가입">
         <ContinueWithGoogle />
       </a>
       <div className="flex w-full items-center gap-[12px]">

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -15,6 +15,8 @@ export default function Header() {
     const eventMatch = location.pathname.match(/^\/event\/([^\/]+)/);
     if (eventMatch) {
       setRedirectUrl(`/event/${eventMatch[1]}`);
+    } else {
+      setRedirectUrl(null);
     }
   };
 
@@ -37,7 +39,11 @@ export default function Header() {
   return (
     <header className="sticky top-0 z-40 flex w-full h-16 justify-center border-b box-content bg-white">
       <div className="flex w-full h-full items-center justify-between px-6 sm:w-screen-sm md:w-screen-md lg:w-screen-lg xl:max-w-screen-xl">
-        <Link to="/" className="flex items-center space-x-2">
+        <Link
+          to="/"
+          className="flex items-center space-x-2"
+          onClick={() => setRedirectUrl(null)}
+        >
           <img src="/moiming-symbol.svg" alt="logo" />
           <p className="moiming">모이밍</p>
         </Link>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,12 +3,20 @@ import { Button } from '@/components/ui/button';
 import useAuth from '@/hooks/useAuth';
 import useAuthStore from '@/hooks/useAuthStore';
 import { useEffect } from 'react';
-import { Link } from 'react-router';
+import { Link, useLocation } from 'react-router';
 
 export default function Header() {
   const { user, handleLogout, refreshUser } = useAuth();
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const setRedirectUrl = useAuthStore((state) => state.setRedirectUrl);
+  const location = useLocation();
+
+  const handleAuthClick = () => {
+    const eventMatch = location.pathname.match(/^\/event\/([^\/]+)/);
+    if (eventMatch) {
+      setRedirectUrl(`/event/${eventMatch[1]}`);
+    }
+  };
 
   useEffect(() => {
     // 1. 로그인 상태가 아니면 타이머를 돌릴 필요가 없음
@@ -36,22 +44,12 @@ export default function Header() {
         <div className="flex items-center gap-1.5">
           {!isLoggedIn || !user ? (
             <>
-              <Link
-                to="/login"
-                onClick={() =>
-                  setRedirectUrl(location.pathname + location.search)
-                }
-              >
+              <Link to="/login" onClick={handleAuthClick}>
                 <Button variant="ghost" className="px-2 py-2">
                   <span className="single-line-body-base">로그인</span>
                 </Button>
               </Link>
-              <Link
-                to="/"
-                onClick={() =>
-                  setRedirectUrl(location.pathname + location.search)
-                }
-              >
+              <Link to="/" onClick={handleAuthClick}>
                 <Button variant="ghost" className="px-2 py-2">
                   <span className="single-line-body-base">회원가입</span>
                 </Button>


### PR DESCRIPTION
### 📝 작업 내용

- 기존에는 헤더와 `authbox` 페이지에서 항상 진입 직전 url을 저장하였는데, 이벤트와 관련된 페이지에서만 url을 저장하도록 로직을 수정했습니다.
- 다음과 같은 경우 원하지 않는 페이지로 리다이렉트가 될 가능성이 있어 방어 로직을 추가했습니다.(완벽하게 방어는 실패했습니다...)
  - eventmain(1번 이벤트) -> 헤더 눌러서 로그인창 진입 -> 다시 기존 페이지로 돌아감 -> 홈페이지로 이동 -> eventmain(2번 이벤트) -> 홈페이지 -> 홈페이지에서 헤더 누르고 로그인 -> 로그인 성공 
  - 위와 같은 경우 로그인 성공 이후 1번 이벤트 페이지로 이동하는 현상을 막기 위해 홈페이지에서 헤더를 누르고 로그인/회원가입을 한 경우와 헤더의 모이밍 로고를 클릭해서 홈페이지로 돌아간 경우 redirecturl을 삭제하도록 로직을 수정했습니다.
 

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)
- 다음 3가지 경우는 여전히 로그인 성공 이후 1번 이벤트로 리다이렉트됩니다.
  - 홈페이지에서 헤더를 누르지 않고, 박스 내부의 **이미 계정이 있나요? 로그인** 버튼을 눌러서 로그인 한 경우
  - 홈페이지로 이동할 때 뒤로가기를 이용해서 이벤트 페이지에서 나간 경우
  - 강제로 `/login`에 접근해서 로그인한 경우 

- 이런 특이 케이스를 막기 위해 **전역 감시자**를 도입하는 것을 ai가 추천했는데, 현재 회원가입 페이지와 홈페이지가 통합되어 있어 도입이 어렵습니다.
  - 전역 감시자는, `redirectUrl` 이 있을 때 url을 검사하여 `/event`, `/login`, `/sign-up`, `/auth`가 아니면 항상 `redirectUrl`을 삭제하는 방식으로 작동합니다.
  - 현재 회원가입 페이지가 홈페이지와 통합되어있기 때문에, eventmain -> 헤더 눌러서 회원가입 -> 전역 감시자에 의해 url 삭제 와 같은 현상이 벌어집니다.

- 추후 홈페이지와 회원가입 페이지를 분리한다면, 전역 감시자를 도입하는 것이 엣지 케이스 방어에 더 효율적일 것 같습니다.