### PR TITLE
🦺 Always allow to edit the registration opening time

### DIFF
--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -107,7 +107,6 @@ interface EventFormProps {
   saveDialogTitle?: string;
   saveDialogDescription?: string;
   mode?: 'create' | 'edit';
-  isRegistrationClosed?: boolean;
 }
 
 export function EventForm({
@@ -120,7 +119,6 @@ export function EventForm({
   saveDialogTitle = '일정을 저장하시겠습니까?',
   saveDialogDescription = '참여자가 생기는 경우, 기본 정보를 수정하기 어려울 수 있습니다.',
   mode = 'create',
-  isRegistrationClosed = false,
 }: EventFormProps) {
   const [step, setStep] = useState<1 | 2>(1);
   const [showSaveDialog, setShowSaveDialog] = useState(false);
@@ -466,7 +464,7 @@ export function EventForm({
                             value={field.value}
                             onChange={field.onChange}
                             placeholder="언제 시작할까요?"
-                            disabled={isFromNow || isRegistrationClosed}
+                            disabled={isFromNow}
                           />
                         )}
                       />

--- a/src/routes/EventEdit.tsx
+++ b/src/routes/EventEdit.tsx
@@ -36,7 +36,6 @@ export default function EventEdit() {
 
   const event = data?.event;
 
-
   const defaultValues = useMemo<FormValues>(() => {
     if (!event) return null as unknown as FormValues;
     const now = new Date();

--- a/src/routes/EventEdit.tsx
+++ b/src/routes/EventEdit.tsx
@@ -36,12 +36,6 @@ export default function EventEdit() {
 
   const event = data?.event;
 
-  const isRegistrationClosed = useMemo(
-    () =>
-      !!event?.registrationEndsAt &&
-      new Date(event.registrationEndsAt) <= new Date(),
-    [event]
-  );
 
   const defaultValues = useMemo<FormValues>(() => {
     if (!event) return null as unknown as FormValues;
@@ -144,7 +138,6 @@ export default function EventEdit() {
       saveDialogTitle="일정을 수정하시겠습니까?"
       saveDialogDescription="바뀐 내용은 신청자에게 자동으로 전달되지 않습니다. 중요한 수정사항은 직접 안내해 주세요."
       mode="edit"
-      isRegistrationClosed={isRegistrationClosed}
     />
   );
 }


### PR DESCRIPTION
### 📝 작업 내용

- 신청 마감 여부에 관계없이 모집 시작 시간을 수정할 수 있도록 하였습니다.

### 📸 스크린샷

없음

### 🚀 리뷰 요구사항

없음