### PR TITLE
🔧 Increase global api timeout

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -9,8 +9,8 @@ interface ApiErrorResponse {
   message: string;
 }
 
-// 5분 버퍼 (밀리초)
-const BUFFER_TIME = 5 * 60 * 1000;
+// 10분 버퍼 (밀리초)
+const BUFFER_TIME = 10 * 60 * 1000;
 
 // 공통 설정을 가진 axios 인스턴스 생성
 const apiClient = axios.create({


### PR DESCRIPTION
### 📝 작업 내용

- API의 전역 timeout이 5초 -> 10초로 증가되었습니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)
