### PR TITLE
🔨 Use proxy in dev mode & co.

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -14,7 +14,10 @@ const BUFFER_TIME = 10 * 60 * 1000;
 
 // 공통 설정을 가진 axios 인스턴스 생성
 const apiClient = axios.create({
-  baseURL: `${import.meta.env.VITE_API_BASE_URL}/api`,
+  // Use proxy in dev mode
+  baseURL: import.meta.env.DEV
+    ? '/api'
+    : `${import.meta.env.VITE_API_BASE_URL}/api`,
   timeout: 5000,
   headers: { 'Content-Type': 'application/json' },
 });

--- a/src/components/ContinueWithGoogle.tsx
+++ b/src/components/ContinueWithGoogle.tsx
@@ -7,7 +7,7 @@ export default function ContinueWithGoogle() {
       viewBox="0 0 189 40"
       fill="none"
     >
-      <g clip-path="url(#clip0_494_4168)">
+      <g clipPath="url(#clip0_494_4168)">
         <path
           d="M169 0.5H20C9.23045 0.5 0.5 9.23045 0.5 20C0.5 30.7696 9.23045 39.5 20 39.5H169C179.77 39.5 188.5 30.7696 188.5 20C188.5 9.23045 179.77 0.5 169 0.5Z"
           fill="white"

--- a/src/components/GlobalErrorModal.tsx
+++ b/src/components/GlobalErrorModal.tsx
@@ -44,7 +44,7 @@ export function GlobalErrorModal() {
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogAction onClick={handleConfirm}>
+          <AlertDialogAction onClick={handleConfirm} autoFocus>
             {confirmText}
           </AlertDialogAction>
         </AlertDialogFooter>

--- a/src/hooks/useInfiniteMyEvents.ts
+++ b/src/hooks/useInfiniteMyEvents.ts
@@ -2,7 +2,7 @@ import getMyEvents from '@/api/events/me';
 import type { MyEventsResponse } from '@/types/events';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-export default function useInfiniteMyEvents() {
+export default function useInfiniteMyEvents(enabled = true) {
   return useInfiniteQuery<MyEventsResponse, Error>({
     queryKey: ['myEvents'],
     queryFn: async ({ pageParam = undefined }) => {
@@ -16,5 +16,6 @@ export default function useInfiniteMyEvents() {
       return undefined;
     },
     initialPageParam: undefined,
+    enabled,
   });
 }

--- a/src/hooks/useInfiniteMyRegistrations.ts
+++ b/src/hooks/useInfiniteMyRegistrations.ts
@@ -2,7 +2,7 @@ import getMyRegistrations from '@/api/registrations/me';
 import type { MyRegistrationsResponse } from '@/types/registrations';
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-export default function useInfiniteMyRegistrations() {
+export default function useInfiniteMyRegistrations(enabled = true) {
   return useInfiniteQuery<MyRegistrationsResponse, Error>({
     queryKey: ['myRegistrations'],
     initialPageParam: 0,
@@ -21,5 +21,6 @@ export default function useInfiniteMyRegistrations() {
       }
       return allPages.length; // Next page number (0-indexed)
     },
+    enabled,
   });
 }

--- a/src/mocks/handlers/user.ts
+++ b/src/mocks/handlers/user.ts
@@ -3,7 +3,9 @@ import { http, HttpResponse } from 'msw';
 import { userDB } from '../db/user.db';
 import type { MockUser } from '../types';
 
-const BASE_URL = `${import.meta.env.VITE_API_BASE_URL}/api`;
+const BASE_URL = import.meta.env.DEV
+  ? '/api'
+  : `${import.meta.env.VITE_API_BASE_URL}/api`;
 
 export const userHandlers = [
   // GET /users/me

--- a/src/mocks/utils.ts
+++ b/src/mocks/utils.ts
@@ -1,5 +1,7 @@
 // 핸들러 주소를 생성해주는 간단한 헬퍼 함수
 export const path = (endpoint: string) => {
-  const baseUrl = import.meta.env.VITE_API_BASE_URL || '';
+  const baseUrl = import.meta.env.DEV
+    ? ''
+    : import.meta.env.VITE_API_BASE_URL || '';
   return `${baseUrl}/api${endpoint}`;
 };

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -23,7 +23,7 @@ export default function Home() {
     hasNextPage: hasNextHosted,
     isFetchingNextPage: isFetchingHosted,
     isLoading: isLoadingHosted,
-  } = useInfiniteMyEvents();
+  } = useInfiniteMyEvents(isLoggedIn);
 
   const {
     data: joinedData,
@@ -31,7 +31,7 @@ export default function Home() {
     hasNextPage: hasNextJoined,
     isFetchingNextPage: isFetchingJoined,
     isLoading: isLoadingJoined,
-  } = useInfiniteMyRegistrations();
+  } = useInfiniteMyRegistrations(isLoggedIn);
 
   // 바닥 감지 훅
   const { ref, inView } = useInView();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,7 +20,7 @@ export default defineConfig(({ mode }) => {
         '/api': {
           target: API_TARGET,
           changeOrigin: true,
-          secure: true,
+          secure: false,
           configure: (proxy) => {
             proxy.on('error', (err, _req, _res) => {
               console.error('proxy error', err);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,14 +1,40 @@
 import path from 'path';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const API_TARGET = env.VITE_API_BASE_URL;
+
+  return {
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
+    server: {
+      proxy: {
+        '/api': {
+          target: API_TARGET,
+          changeOrigin: true,
+          secure: true,
+          configure: (proxy) => {
+            proxy.on('error', (err, _req, _res) => {
+              console.error('proxy error', err);
+            });
+            proxy.on('proxyReq', (proxyReq, req, _res) => {
+              console.info('-→', req.method, req.url);
+              proxyReq.removeHeader('origin'); // 서버에서 내려오는 CORS 에러 방지
+            });
+            proxy.on('proxyRes', (proxyRes, req, _res) => {
+              console.info('←-', proxyRes.statusCode, req.url);
+            });
+          },
+        },
+      },
+    },
+  };
 });


### PR DESCRIPTION
### 📝 작업 내용

- Vite 개발 서버 프록시를 설정하였습니다. 이제, 개발 모드에서 API와 연결할 때 CORS 설정과 인증서를 신경 쓰지 않아도 됩니다.
  - 덤으로, 서버와의 통신이 있으면 터미널 창에 로그가 나타나도록 했습니다.
- 랜딩 페이지에서, 로그인하지 않았을 때에도 계속해서 서버에 `/events/me`와 `registrations/me` 요청을 넣었습니다. 로그인하지 않은 경우에는 대시보드를 그릴 필요가 없으므로, 로그인했을 때만 서버에 요청을 넣도록 하였습니다.
- 이외 콘솔에서 나타나는 경고를 수정하기 위해, 다음을 수정하였습니다.
  - 모달이 나타났을 때 자동으로 초점이 모달로 이동하도록 설정했습니다.
  - SVG에서 `clip-path`로 적혀 있던 속성을 `clipPath`로 바꾸었습니다.

### 📸 스크린샷

<img width="508" height="315" alt="스크린샷 2026-04-04 17 22 07" src="https://github.com/user-attachments/assets/93a257a9-814a-4517-a778-407e1de095e7" />

### 🚀 리뷰 요구사항

- 환경변수 `VITE_API_BASE_URL`이 `https://api.moiming.app`일 때와 `https://api.dev.moiming.app`일 때 서버 프록시가 잘 작동하고 있음을 확인했습니다. 서버 이전 후 재확인이 필요할 수도 있겠습니다.
- `yarn dev`를 실행하면 서버와의 통신 로그가 터미널 창에 남도록 했습니다. 로그가 찍히는 것이 오히려 불편하다면, `vite.config.ts` 파일에서 이 설정을 지우셔도 좋습니다.