### PR TITLE
💬 `일정` → `모임`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,4 +89,4 @@ yarn dev
 | [박준영(@young-52)](https://github.com/young-52) | [이준엽(@jun-0411)](https://github.com/jun-0411) |
 | :---: | :---: |
 | <a href="https://github.com/young-52"><img src="https://avatars.githubusercontent.com/u/25864819?v=4" width="150"></a> | <a href="https://github.com/jun-0411"><img src="https://avatars.githubusercontent.com/u/202625805?v=4" width="150"></a> |
-| 랜딩, 로그인, <br> 회원가입, 일정 생성 | 일정 상세, 참여자, <br> 일정 수정, 프로필 수정 |
+| 랜딩, 로그인, <br> 회원가입, 모임 생성 | 모임 상세, 참여자, <br> 모임 수정, 프로필 수정 |

--- a/src/api/events/event.ts
+++ b/src/api/events/event.ts
@@ -6,7 +6,7 @@ import type {
 } from '@/types/events';
 import apiClient from '../apiClient';
 
-// 일정 생성 (POST /api/events)
+// 모임 생성 (POST /api/events)
 export async function createEvent(data: CreateEventRequest) {
   const response = await apiClient.post(`/events`, data);
 
@@ -16,7 +16,7 @@ export async function createEvent(data: CreateEventRequest) {
   };
 }
 
-// 일정 상세 응답 (GET /api/events/:id)
+// 모임 상세 응답 (GET /api/events/:id)
 export async function getEventDetail(id: string) {
   const response = await apiClient.get<EventDetailResponse>(`/events/${id}`);
 
@@ -26,7 +26,7 @@ export async function getEventDetail(id: string) {
   };
 }
 
-// 일정 수정 (PUT /api/events/:id)
+// 모임 수정 (PUT /api/events/:id)
 export async function updateEvent(id: string, data: UpdateEventRequest) {
   const response = await apiClient.put<UpdateEventResponse>(
     `/events/${id}`,
@@ -39,7 +39,7 @@ export async function updateEvent(id: string, data: UpdateEventRequest) {
   };
 }
 
-// 일정 삭제 (DELETE /api/events/:id)
+// 모임 삭제 (DELETE /api/events/:id)
 export async function deleteEvent(id: string) {
   const response = await apiClient.delete(`/events/${id}`);
 

--- a/src/api/events/me.ts
+++ b/src/api/events/me.ts
@@ -1,7 +1,7 @@
 import type { MyEventsResponse } from '@/types/events';
 import apiClient from '../apiClient';
 
-// 내가 생성한 일정 목록 (GET /api/events/me)
+// 내가 생성한 모임 목록 (GET /api/events/me)
 export default async function getMyEvents(cursor?: string) {
   const response = await apiClient.get<MyEventsResponse>(`/events/me`, {
     params: { cursor },

--- a/src/api/registrations/me.ts
+++ b/src/api/registrations/me.ts
@@ -1,7 +1,7 @@
 import apiClient from '@/api/apiClient';
 import type { MyRegistrationsResponse } from '@/types/registrations';
 
-// 내가 신청한 일정 조회 (GET /api/registrations/me)
+// 내가 신청한 모임 조회 (GET /api/registrations/me)
 export default async function getMyRegistrations(
   page: number = 0,
   size: number = 5

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -24,12 +24,12 @@ export default function Dashboard({
         <div className="flex flex-col gap-5 items-center w-full max-w-md mx-auto">
           <div className="flex flex-col gap-1">
             <h1 className="text-center">
-              {isHosted ? '생성된 일정이 없어요.' : '참여한 일정이 없어요.'}
+              {isHosted ? '생성된 모임이 없어요.' : '참여한 모임이 없어요.'}
             </h1>
             <span className="body-base text-[#757575] text-center">
               {isHosted
-                ? '일정을 만들고 모임을 시작해보세요.'
-                : '모임에 참여하고 일정을 확인해보세요.'}
+                ? '나만의 모임을 만들어 보세요.'
+                : '다른 사람이 여는 모임에 참여해 보세요.'}
             </span>
           </div>
           <div className="flex px-1 py-1 justify-center">

--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -116,7 +116,7 @@ export function EventForm({
   loading = false,
   onBack,
   submitButtonText = '저장',
-  saveDialogTitle = '일정을 저장하시겠습니까?',
+  saveDialogTitle = '모임을 저장하시겠습니까?',
   saveDialogDescription = '참여자가 생기는 경우, 기본 정보를 수정하기 어려울 수 있습니다.',
   mode = 'create',
 }: EventFormProps) {
@@ -273,7 +273,7 @@ export function EventForm({
                         <Input
                           {...field}
                           id="title"
-                          placeholder="어떤 일정인가요? (최대 20자)"
+                          placeholder="어떤 모임인가요? (최대 20자)"
                           className={`text-lg ${
                             errors.title
                               ? 'border-destructive focus:ring-destructive/10'
@@ -395,7 +395,7 @@ export function EventForm({
                         <Textarea
                           {...field}
                           id="description"
-                          placeholder="이번 일정은 어떤 일정인가요? 모임을 설명해 주세요."
+                          placeholder="이번 모임은 어떤 모임인가요? 모임을 설명해 주세요."
                           className="h-20 body-base"
                           value={field.value ?? ''}
                         />
@@ -429,7 +429,7 @@ export function EventForm({
                     <FieldContent>
                       <FieldLabel>지금부터 모집하기</FieldLabel>
                       <FieldDescription>
-                        일정을 만든 즉시 참가 신청을 시작해요.
+                        모임을 만든 즉시 참가 신청을 시작해요.
                       </FieldDescription>
                     </FieldContent>
                     <Controller

--- a/src/components/NewEventButton.tsx
+++ b/src/components/NewEventButton.tsx
@@ -13,7 +13,7 @@ export default function NewEventButton() {
     <Button onClick={onNewEventClicked} className="h-[40px]">
       <Plus stroke="#F1F6FD" width="16" height="16" />
       <span className="single-line-body-base text-primary-foreground">
-        새 일정 만들기
+        새 모임 만들기
       </span>
     </Button>
   );

--- a/src/components/Subheader.tsx
+++ b/src/components/Subheader.tsx
@@ -69,10 +69,10 @@ export default function Subheader({
                 <AlertDialogContent>
                   <AlertDialogHeader>
                     <AlertDialogTitle>
-                      정말 일정을 삭제하시겠습니까?
+                      정말 모임을 삭제하시겠습니까?
                     </AlertDialogTitle>
                     <AlertDialogDescription>
-                      삭제된 일정은 복구할 수 없습니다.
+                      삭제된 모임은 복구할 수 없습니다.
                     </AlertDialogDescription>
                   </AlertDialogHeader>
                   <AlertDialogFooter>

--- a/src/hooks/useEventDetail.ts
+++ b/src/hooks/useEventDetail.ts
@@ -33,13 +33,13 @@ export default function useEventDetail(id?: string) {
     (state) => state.removeGuestRegistration
   );
 
-  // 2. 일정 상세 정보 로드 핸들러
+  // 2. 모임 상세 정보 로드 핸들러
   const handleFetchDetail = useCallback(
     async (eventId: string) => {
       setLoading(true);
       setIsDeleted(false);
       try {
-        // (1) 기본 일정 정보 가져오기
+        // (1) 기본 모임 정보 가져오기
         const eventRes = await getEventDetail(eventId);
         let mergedData = eventRes.data;
 
@@ -47,7 +47,7 @@ export default function useEventDetail(id?: string) {
         if (mergedData.event.title) {
           document.title = `${mergedData.event.title} - 모이밍`;
         } else {
-          document.title = '일정 상세 - 모이밍';
+          document.title = '모임 상세 - 모이밍';
         }
 
         if (mergedData.viewer.status === 'NONE' && effectiveRegId) {
@@ -151,7 +151,7 @@ export default function useEventDetail(id?: string) {
     }
   };
 
-  // 6. 일정 삭제 로직 핸들러
+  // 6. 모임 삭제 로직 핸들러
   const handleDeleteEvent = async (eventId: string) => {
     setLoading(true);
     try {

--- a/src/mocks/handlers/event.ts
+++ b/src/mocks/handlers/event.ts
@@ -8,7 +8,7 @@ import { eventDB } from '../db/event.db';
 import { path } from '../utils';
 
 export const eventHandlers = [
-  // 1. 내가 생성한/참여한 일정 목록 조회 (GET /events/me)
+  // 1. 내가 생성한/참여한 모임 목록 조회 (GET /events/me)
   // :id 보다 먼저 정의되어야 'me'를 id로 인식하지 않음
   http.get(path('/events/me'), async ({ request }) => {
     const url = new URL(request.url);
@@ -53,7 +53,7 @@ export const eventHandlers = [
     });
   }),
 
-  // 2. 일정 상세 정보 조회 (GET /events/:id)
+  // 2. 모임 상세 정보 조회 (GET /events/:id)
   http.get(path('/events/:id'), async ({ params }) => {
     const { id } = params;
     await delay(300);
@@ -107,7 +107,7 @@ export const eventHandlers = [
     return new HttpResponse(null, { status: 200 });
   }),
 
-  // 5. 일정 생성 (POST /events)
+  // 5. 모임 생성 (POST /events)
   http.post(path('/events'), async ({ request }) => {
     const body = (await request.json()) as CreateEventRequest;
     await delay(500);

--- a/src/mocks/handlers/registrations.ts
+++ b/src/mocks/handlers/registrations.ts
@@ -4,7 +4,7 @@ import { eventDB } from '../db/event.db';
 import { path } from '../utils';
 
 export const registrationHandlers = [
-  // 내가 신청한 일정 조회 (GET /registrations/me)
+  // 내가 신청한 모임 조회 (GET /registrations/me)
   http.get(path('/registrations/me'), async ({ request }) => {
     const url = new URL(request.url);
     const page = parseInt(url.searchParams.get('page') || '0', 10);

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -52,7 +52,7 @@ export const router = createBrowserRouter([
     path: '/new-event',
     Component: RootLayout,
     children: [{ index: true, Component: NewEvent }],
-    handle: { title: '일정 만들기 - 모이밍' },
+    handle: { title: '모임 만들기 - 모이밍' },
   },
   {
     path: '/event/:id',
@@ -63,6 +63,6 @@ export const router = createBrowserRouter([
       { path: 'register', Component: EventRegister },
       { path: 'edit', Component: EventEdit },
     ],
-    handle: { title: '일정 상세 - 모이밍' },
+    handle: { title: '모임 상세 - 모이밍' },
   },
 ]);

--- a/src/routes/EventEdit.tsx
+++ b/src/routes/EventEdit.tsx
@@ -65,10 +65,10 @@ export default function EventEdit() {
         </div>
         <div className="space-y-2">
           <h2 className="text-2xl font-bold text-gray-900">
-            삭제되었거나 없는 일정입니다.
+            삭제되었거나 없는 모임입니다.
           </h2>
           <p className="text-gray-500">
-            요청하신 일정 정보를 찾을 수 없습니다.
+            요청하신 모임 정보를 찾을 수 없습니다.
           </p>
         </div>
         <Button onClick={() => navigate('/')} className="rounded-xl px-8 h-12">
@@ -81,8 +81,8 @@ export default function EventEdit() {
   if (fetchLoading || !data) {
     return (
       <LoadingSkeleton
-        loadingTitle="일정 정보를 불러오는 중입니다"
-        message="잠시만 기다려주세요. 일정 정보를 불러오고 있습니다."
+        loadingTitle="모임 정보를 불러오는 중입니다"
+        message="잠시만 기다려주세요. 모임 정보를 불러오고 있습니다."
       />
     );
   }
@@ -116,7 +116,7 @@ export default function EventEdit() {
       const response = await updateEvent(id, payload);
 
       if (response.status === 201 || response.status === 200) {
-        toast.success('일정이 수정되었습니다.');
+        toast.success('모임이 수정되었습니다.');
         navigate(`/event/${id}`);
       }
     } catch (error) {
@@ -128,13 +128,13 @@ export default function EventEdit() {
 
   return (
     <EventForm
-      pageTitle="일정 수정하기"
+      pageTitle="모임 수정하기"
       defaultValues={defaultValues}
       onSubmit={handleSubmit}
       loading={isSubmitting}
       onBack={() => navigate(-1)}
       submitButtonText="수정하기"
-      saveDialogTitle="일정을 수정하시겠습니까?"
+      saveDialogTitle="모임을 수정하시겠습니까?"
       saveDialogDescription="바뀐 내용은 신청자에게 자동으로 전달되지 않습니다. 중요한 수정사항은 직접 안내해 주세요."
       mode="edit"
     />

--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -75,10 +75,10 @@ export default function EventMain() {
         </div>
         <div className="space-y-2">
           <h2 className="text-2xl font-bold text-gray-900">
-            삭제되었거나 없는 일정입니다.
+            삭제되었거나 없는 모임입니다.
           </h2>
           <p className="text-gray-500">
-            요청하신 일정 정보를 찾을 수 없습니다.
+            요청하신 모임 정보를 찾을 수 없습니다.
           </p>
         </div>
         <Button onClick={() => navigate('/')} className="rounded-xl px-8 h-12">
@@ -91,8 +91,8 @@ export default function EventMain() {
   if (loading || !data) {
     return (
       <LoadingSkeleton
-        loadingTitle="일정 정보를 불러오는 중입니다"
-        message="잠시만 기다려주세요. 일정 정보를 불러오고 있습니다."
+        loadingTitle="모임 정보를 불러오는 중입니다"
+        message="잠시만 기다려주세요. 모임 정보를 불러오고 있습니다."
       />
     );
   }
@@ -129,7 +129,7 @@ export default function EventMain() {
   const onDeleteClick = async () => {
     const success = await handleDeleteEvent(id);
     if (success) {
-      toast.success('일정이 삭제되었습니다.');
+      toast.success('모임이 삭제되었습니다.');
       navigate('/');
     }
   };

--- a/src/routes/EventRegister.tsx
+++ b/src/routes/EventRegister.tsx
@@ -35,8 +35,8 @@ export default function EventRegister() {
   if (loading || !data) {
     return (
       <LoadingSkeleton
-        loadingTitle="일정 정보를 불러오는 중입니다"
-        message="잠시만 기다려주세요. 일정 정보를 불러오고 있습니다."
+        loadingTitle="모임 정보를 불러오는 중입니다"
+        message="잠시만 기다려주세요. 모임 정보를 불러오고 있습니다."
       />
     );
   }

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -96,7 +96,7 @@ export default function Home() {
       <div className="flex flex-col flex-1 w-full max-w-2xl mx-auto px-4 py-4 gap-6">
         <LoadingSkeleton
           loadingTitle="불러오는 중..."
-          message="일정 정보를 가져오고 있습니다."
+          message="모임 정보를 가져오고 있습니다."
         />
       </div>
     );
@@ -108,7 +108,7 @@ export default function Home() {
 
   return (
     <div className="flex flex-col flex-1 w-full max-w-2xl mx-auto px-4 py-4 gap-4">
-      {/* 새 일정 만들기 버튼 */}
+      {/* 새 모임 만들기 버튼 */}
       <div className="flex items-center justify-end mb-4">
         <NewEventButton />
       </div>
@@ -151,7 +151,7 @@ export default function Home() {
               ? events.length > 0
               : registrations.length > 0
           ) ? (
-          <p className="body-small text-muted-foreground">마지막 일정입니다.</p>
+          <p className="body-small text-muted-foreground">마지막 모임입니다.</p>
         ) : null}
       </div>
     </div>

--- a/src/routes/NewEvent.tsx
+++ b/src/routes/NewEvent.tsx
@@ -54,21 +54,21 @@ export default function NewEvent() {
     const eventId = await createEvent(payload);
 
     if (eventId) {
-      toast.success('일정이 성공적으로 생성되었습니다!');
+      toast.success('모임이 성공적으로 생성되었습니다!');
       navigate(`/event/${eventId}`);
     }
   };
 
   return (
     <EventForm
-      pageTitle="일정 만들기"
+      pageTitle="모임 만들기"
       defaultValues={defaultValues}
       onSubmit={onSubmit}
       loading={loading}
       onBack={() => navigate(-1)}
       submitButtonText="저장"
-      saveDialogTitle="일정을 저장하시겠습니까?"
-      saveDialogDescription="일정을 저장한 이후에도 수정 및 삭제가 가능합니다."
+      saveDialogTitle="모임을 저장하시겠습니까?"
+      saveDialogDescription="모임을 저장한 이후에도 수정 및 삭제가 가능합니다."
       mode="create"
     />
   );


### PR DESCRIPTION
### 📝 작업 내용

- 서비스 내에 혼재하던 표현 '일정'과 '모임'을 '일정'으로 모두 통일하였습니다.

### 📸 스크린샷

없음

### 🚀 리뷰 요구사항

없음