### PR TITLE
💄 Fix desktop scrollbar sytle

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -12,7 +12,6 @@
 @layer base {
   html,
   body {
-    scrollbar-gutter: stable;
     @apply h-full;
 
     font-family:
@@ -403,5 +402,24 @@
   }
   body {
     @apply bg-background text-foreground;
+  }
+
+  body[data-scroll-locked] {
+    padding-right: 0px !important;
+  }
+
+  ::-webkit-scrollbar {
+    width: 6px;
+    height: 6px;
+  }
+  ::-webkit-scrollbar-track {
+    background-color: transparent;
+  }
+  ::-webkit-scrollbar-thumb {
+    background-color: #d4d4d4;
+    border-radius: 10px;
+  }
+  ::-webkit-scrollbar-thumb:hover {
+    background-color: #a3a3a3;
   }
 }

--- a/src/components/ProfileButton.tsx
+++ b/src/components/ProfileButton.tsx
@@ -27,7 +27,7 @@ export default function ProfileButton({
   };
 
   return (
-    <DropdownMenu>
+    <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
         <button>
           <UserAvatar


### PR DESCRIPTION
### 📝 작업 내용

- 데스크탑 환경에서 스크롤바 디자인을 모바일 환경과 비슷하게 수정했습니다.
- 헤더의 드롭다운 메뉴가 선택되면 스크롤바가 없어져 ui.가 깜빡이는 현상을 수정했습니다. 기존에는 드롭다운 메뉴가 활성화되면 메인 화면의 스크롤이 불가능했습니다. 드롭다운 메뉴가 활성화될 때도 메인 화면 스크롤이 가능하게 수정했습니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 저번주에 담당했던 이슈라 우선적으로 처리했습니다. 이후 #150 이슈부터 처리하겠습니다.
