### PR TITLE
💄 Update eventmain footer design

### DIFF
--- a/src/components/ProfileButton.tsx
+++ b/src/components/ProfileButton.tsx
@@ -29,7 +29,7 @@ export default function ProfileButton({
   return (
     <DropdownMenu modal={false}>
       <DropdownMenuTrigger asChild>
-        <button>
+        <button className="cursor-pointer">
           <UserAvatar
             name={user.name}
             imageUrl={user.profileImage}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,7 +9,8 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        default:
+          'bg-primary text-primary-foreground hover:bg-primary/90 cursor-pointer',
         moiming:
           'bg-primary text-white shadow-md hover:bg-primary/90 font-bold rounded-2xl',
         moimingOutline:
@@ -21,7 +22,7 @@ const buttonVariants = cva(
         secondary:
           'bg-secondary text-secondary-foreground hover:bg-secondary/80 border-2 border-gray-500',
         ghost:
-          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50',
+          'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 cursor-pointer',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {

--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -147,9 +147,7 @@ export default function EventMain() {
   };
 
   return (
-    <div
-      className={`flex flex-col ${view === 'ADMIN' ? 'pb-47' : 'pb-38 py-6'}`}
-    >
+    <div className="flex flex-col pb-38 py-6">
       {/* 1. 상단 네비게이션 */}
       {view === 'ADMIN' && (
         <Subheader
@@ -418,16 +416,13 @@ ${event.description}`;
             모임 내용 텍스트 함께 복사하기
           </label>
         </div>
-        <span className="text-base text-gray-400 font-mono tracking-tighter">
-          {joinLink}
-        </span>
         <Button
           variant="moiming"
           size="xl"
           onClick={onCopyLink}
           className="w-full px-6 flex"
         >
-          <LinkIcon className="w-5 h-5" /> 링크 복사하기
+          <LinkIcon className="w-5 h-5" /> 공유 링크 복사하기
         </Button>
       </>
     );

--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -147,7 +147,7 @@ export default function EventMain() {
   };
 
   return (
-    <div className="flex flex-col pb-38 py-6">
+    <div className="flex flex-col pb-40">
       {/* 1. 상단 네비게이션 */}
       {view === 'ADMIN' && (
         <Subheader
@@ -281,7 +281,7 @@ function StatusBanner({
       animate={{ opacity: 1, y: 0 }}
       className="w-full space-y-4"
     >
-      <div className="flex flex-col items-start gap-6">
+      <div className="flex flex-col items-start gap-6 pt-6">
         <div className="flex items-center gap-2">
           <div
             className={`size-9 rounded-full flex items-center justify-center ${current.bg}`}

--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -411,18 +411,17 @@ ${event.description}`;
           />
           <label
             htmlFor="copy"
-            className="text-base text-gray-900 font-medium cursor-pointer"
+            className="body-base text-[#1e1e1e] cursor-pointer"
           >
             모임 내용 텍스트 함께 복사하기
           </label>
         </div>
         <Button
-          variant="moiming"
           size="xl"
           onClick={onCopyLink}
-          className="w-full px-6 flex"
+          className="w-full body-strong px-6 flex gap-2"
         >
-          <LinkIcon className="w-5 h-5" /> 공유 링크 복사하기
+          <LinkIcon className="w-4 h-4" /> 공유 링크 복사하기
         </Button>
       </>
     );

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -73,7 +73,7 @@ export default function Home() {
           </div>
           <div className="flex flex-col gap-3.5">
             <Link to="/sign-up">
-              <Button className="w-full single-line-body-base p-3 cursor-pointer">
+              <Button className="w-full single-line-body-base p-3">
                 시작하기
               </Button>
             </Link>

--- a/src/routes/SignUp.tsx
+++ b/src/routes/SignUp.tsx
@@ -271,7 +271,7 @@ export default function SignUp() {
 
           <Button
             type="submit"
-            className="w-full h-10 cursor-pointer"
+            className="w-full h-10"
             // disabled={isUploading}
           >
             회원가입


### PR DESCRIPTION
### 📝 작업 내용

- `EventMain` 페이지에서 `host`상태일 때 footer가 본문을 가리는 현상을 수정했습니다.
- 04/21 체크인 회의에서 합의한 의견대로 `host`상태에서 footer에서 보여지는 공유 링크를 삭제하고, 버튼 이름을 '공유 링크 복사하기'로 수정하였습니다. 

### 📸 스크린샷 (선택)

<img width="562" height="1001" alt="image" src="https://github.com/user-attachments/assets/a11ce399-eff3-40de-a321-cdff6d45ef86" />


### 🚀 리뷰 요구사항 (선택)

- 현재 모바일 환경에서 참여자 명단 부분 참여자 아이콘이 footer의 영향으로 반 정도 블러되어 보입니다.
최대 스크롤에서 본문이 블러되는 것이 불편하다면 `EventMain`의 150줄 코드 `<div className="flex flex-col pb-38 py-6">`에서 pb 값을 늘리면 됩니다.