### PR TITLE
💄 Update global modal style & unify modals

### DIFF
--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -547,10 +547,7 @@ export function EventForm({
             </AlertDialogHeader>
             <AlertDialogFooter>
               <AlertDialogCancel>취소</AlertDialogCancel>
-              <AlertDialogAction
-                onClick={handleSubmit(onSubmit)}
-                className="bg-primary text-white hover:bg-primary/90 rounded-xl"
-              >
+              <AlertDialogAction onClick={handleSubmit(onSubmit)}>
                 {submitButtonText}
               </AlertDialogAction>
             </AlertDialogFooter>

--- a/src/components/GlobalErrorModal.tsx
+++ b/src/components/GlobalErrorModal.tsx
@@ -39,7 +39,7 @@ export function GlobalErrorModal() {
           <AlertDialogTitle className="text-destructive">
             {title}
           </AlertDialogTitle>
-          <AlertDialogDescription className="text-base whitespace-pre-wrap">
+          <AlertDialogDescription className="whitespace-pre-wrap">
             {message}
           </AlertDialogDescription>
         </AlertDialogHeader>

--- a/src/components/Subheader.tsx
+++ b/src/components/Subheader.tsx
@@ -76,13 +76,8 @@ export default function Subheader({
                     </AlertDialogDescription>
                   </AlertDialogHeader>
                   <AlertDialogFooter>
-                    <AlertDialogCancel className="rounded-lg">
-                      취소
-                    </AlertDialogCancel>
-                    <AlertDialogAction
-                      onClick={dropdownOptions.onDeleteClick}
-                      className="bg-primary text-white hover:bg-primary/90 rounded-lg"
-                    >
+                    <AlertDialogCancel>취소</AlertDialogCancel>
+                    <AlertDialogAction onClick={dropdownOptions.onDeleteClick}>
                       삭제
                     </AlertDialogAction>
                   </AlertDialogFooter>

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -59,8 +59,8 @@ function AlertDialogContent({
         {...props}
       >
         {props.children}
-        <AlertDialogPrimitive.Cancel className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-          <X className="h-6 w-6 text-gray-900" />
+        <AlertDialogPrimitive.Cancel className="absolute right-4 top-4 rounded-lg opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-5 w-5 text-[#1E1E1E]" />
           <span className="sr-only">Close</span>
         </AlertDialogPrimitive.Cancel>
       </AlertDialogPrimitive.Content>
@@ -104,7 +104,7 @@ function AlertDialogTitle({
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn('text-xl font-bold text-gray-900', className)}
+      className={cn('h2 text-[#1E1E1E]', className)}
       {...props}
     />
   );
@@ -117,7 +117,7 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn('text-base text-gray-700 font-medium', className)}
+      className={cn('body-base text-[#1E1E1E]', className)}
       {...props}
     />
   );
@@ -129,7 +129,7 @@ function AlertDialogAction({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
   return (
     <AlertDialogPrimitive.Action
-      className={cn(buttonVariants(), 'text-base font-bold', className)}
+      className={cn(buttonVariants(), className)}
       {...props}
     />
   );
@@ -141,11 +141,7 @@ function AlertDialogCancel({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
   return (
     <AlertDialogPrimitive.Cancel
-      className={cn(
-        buttonVariants({ variant: 'secondary' }),
-        'text-base font-bold',
-        className
-      )}
+      className={cn(buttonVariants({ variant: 'secondary' }), className)}
       {...props}
     />
   );

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -53,7 +53,7 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-md',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-6 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-md',
           className
         )}
         {...props}

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,4 +1,5 @@
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+import { X } from 'lucide-react';
 import * as React from 'react';
 
 import { buttonVariants } from '@/components/ui/button';
@@ -52,11 +53,17 @@ function AlertDialogContent({
       <AlertDialogPrimitive.Content
         data-slot="alert-dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-md',
           className
         )}
         {...props}
-      />
+      >
+        {props.children}
+        <AlertDialogPrimitive.Cancel className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+          <X className="h-6 w-6 text-gray-900" />
+          <span className="sr-only">Close</span>
+        </AlertDialogPrimitive.Cancel>
+      </AlertDialogPrimitive.Content>
     </AlertDialogPortal>
   );
 }
@@ -68,7 +75,7 @@ function AlertDialogHeader({
   return (
     <div
       data-slot="alert-dialog-header"
-      className={cn('flex flex-col gap-2 text-center sm:text-left', className)}
+      className={cn('flex flex-col gap-3 text-left', className)}
       {...props}
     />
   );
@@ -97,7 +104,7 @@ function AlertDialogTitle({
   return (
     <AlertDialogPrimitive.Title
       data-slot="alert-dialog-title"
-      className={cn('text-lg font-semibold', className)}
+      className={cn('text-xl font-bold text-gray-900', className)}
       {...props}
     />
   );
@@ -110,7 +117,7 @@ function AlertDialogDescription({
   return (
     <AlertDialogPrimitive.Description
       data-slot="alert-dialog-description"
-      className={cn('text-muted-foreground text-sm', className)}
+      className={cn('text-base text-gray-700 font-medium', className)}
       {...props}
     />
   );
@@ -122,7 +129,7 @@ function AlertDialogAction({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
   return (
     <AlertDialogPrimitive.Action
-      className={cn(buttonVariants(), className)}
+      className={cn(buttonVariants(), 'text-base font-bold', className)}
       {...props}
     />
   );
@@ -134,7 +141,11 @@ function AlertDialogCancel({
 }: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
   return (
     <AlertDialogPrimitive.Cancel
-      className={cn(buttonVariants({ variant: 'outline' }), className)}
+      className={cn(
+        buttonVariants({ variant: 'secondary' }),
+        'text-base font-bold',
+        className
+      )}
       {...props}
     />
   );

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,7 +10,7 @@ const buttonVariants = cva(
     variants: {
       variant: {
         default:
-          'bg-primary text-primary-foreground hover:bg-primary/90 cursor-pointer',
+          'bg-primary text-primary-foreground hover:bg-primary/90 border-1 border-bg-primary cursor-pointer',
         moiming:
           'bg-primary text-white shadow-md hover:bg-primary/90 font-bold rounded-2xl',
         moimingOutline:
@@ -20,7 +20,7 @@ const buttonVariants = cva(
         outline:
           'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50',
         secondary:
-          'bg-secondary text-secondary-foreground hover:bg-secondary/80 border-2 border-gray-500',
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80 border-1 border-gray-500 cursor-pointer',
         ghost:
           'hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50 cursor-pointer',
         link: 'text-primary underline-offset-4 hover:underline',

--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -449,7 +449,7 @@ ${event.description}`;
               {current.text}
             </Button>
           </AlertDialogTrigger>
-          <AlertDialogContent className="rounded-[2rem]">
+          <AlertDialogContent>
             <AlertDialogHeader>
               <AlertDialogTitle>취소하시겠습니까?</AlertDialogTitle>
               <AlertDialogDescription>
@@ -457,15 +457,8 @@ ${event.description}`;
               </AlertDialogDescription>
             </AlertDialogHeader>
             <AlertDialogFooter>
-              <AlertDialogCancel className="rounded-xl">
-                신청 유지하기
-              </AlertDialogCancel>
-              <AlertDialogAction
-                onClick={onCancel}
-                className="bg-primary text-white hover:bg-primary/90 rounded-xl"
-              >
-                취소하기
-              </AlertDialogAction>
+              <AlertDialogCancel>신청 유지하기</AlertDialogCancel>
+              <AlertDialogAction onClick={onCancel}>취소하기</AlertDialogAction>
             </AlertDialogFooter>
           </AlertDialogContent>
         </AlertDialog>

--- a/src/routes/Guests.tsx
+++ b/src/routes/Guests.tsx
@@ -158,7 +158,6 @@ export default function Guests() {
                         onClick={() =>
                           handleCancelGuest(guest.name, guest.registrationId)
                         }
-                        className="bg-primary text-white hover:bg-primary/90 rounded-xl"
                       >
                         취소하기
                       </AlertDialogAction>


### PR DESCRIPTION
### 📝 작업 내용

- 글로벌 모달 디자인을 피그마에 맞춰서 수정했습니다.
- 기존에 모달을 호출할 때 스타일을 지정하는 부분을 모두 제거하여 모달 디자인을 통일했습니다.

### 📸 스크린샷 (선택)

<img width="694" height="276" alt="image" src="https://github.com/user-attachments/assets/f12c8a95-6b26-4732-9556-26129723cd77" />


### 🚀 리뷰 요구사항 (선택)

- 피그마에 맞추어 모달 우측 상단에 'X'를 추가했는데, 약간 불필요한 기능처럼 느껴지기도 합니다. 추후 회의에서 의논해보면 좋을 것 같습니다.
- 피그마를 보면 모달에서 "취소하기 - 신청유지하기" 순서와 "신청유지하기 - 취소하기" 순서가 혼용되어있습니다. 모달에 의해 행동을 하게되는 것이 우측 파란 버튼이 되어야 한다고 생각해서 "신청유지하기 - 취소하기"로 우선 통일해두었습니다.
- 피그마 기준으로 "취소 - 저장" 이런 식으로 되어있는 버튼도 많은데, 버튼 문구를 "취소하기 - 저장하기" 등으로 통일하는 것이 좋아 보입니다.
