### PR TITLE
👽 Apply API changes on `/api/registrations`

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -29,8 +29,8 @@ export default function EventCard({
   // Extract values based on the object type
   const publicId = isHosted ? event?.publicId : registration?.publicId;
   const title = isHosted ? event?.title : registration?.title;
-  const startsAt = isHosted ? event?.startsAt : registration?.startAt;
-  const endsAt = isHosted ? event?.endsAt : registration?.endAt;
+  const startsAt = isHosted ? event?.startsAt : registration?.startsAt;
+  const endsAt = isHosted ? event?.endsAt : registration?.endsAt;
   const capacity = isHosted ? event?.capacity : registration?.capacity;
   const applicants = isHosted
     ? event?.confirmedCount
@@ -38,10 +38,10 @@ export default function EventCard({
   const waitlistCount = isHosted ? event?.waitlistCount : null;
   const regStart = isHosted
     ? event?.registrationStartsAt
-    : registration?.registrationStart;
+    : registration?.registrationStartsAt;
   const regEnd = isHosted
     ? event?.registrationEndsAt
-    : registration?.registrationDeadline;
+    : registration?.registrationEndsAt;
 
   const joinLink = `${window.location.origin}/event/${publicId}`;
 
@@ -68,7 +68,7 @@ export default function EventCard({
           <TagMini
             background="bg-[#E5F0FF]"
             foreground="text-[#0055CC]"
-            content={`대기 ${registration.waitingNum}번`}
+            content={`대기 ${registration.waitlistedNum}번`}
           />
         );
       } else if (registration.status === 'CANCELED') {

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -32,10 +32,12 @@ export default function EventCard({
   const startsAt = isHosted ? event?.startsAt : registration?.startsAt;
   const endsAt = isHosted ? event?.endsAt : registration?.endsAt;
   const capacity = isHosted ? event?.capacity : registration?.capacity;
-  const applicants = isHosted
+  const confirmedCount = isHosted
     ? event?.confirmedCount
-    : registration?.registrationCnt;
-  const waitlistCount = isHosted ? event?.waitlistCount : null;
+    : registration?.confirmedCount;
+  const waitlistCount = isHosted
+    ? event?.waitlistCount
+    : registration?.waitlistCount;
   const regStart = isHosted
     ? event?.registrationStartsAt
     : registration?.registrationStartsAt;
@@ -139,7 +141,7 @@ export default function EventCard({
               <User stroke="#757575" width="16" />
               <span className="body-base text-[#757575]">정원</span>
               <span className="body-base">
-                {applicants}/{capacity}명
+                {confirmedCount}/{capacity}명
                 {waitlistCount !== null && waitlistCount !== undefined
                   ? ` (대기자 ${waitlistCount}명)`
                   : ''}

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -140,7 +140,7 @@ export default function EventCard({
               <span className="body-base text-[#757575]">정원</span>
               <span className="body-base">
                 {applicants}/{capacity}명
-                {waitlistCount && waitlistCount > 0
+                {waitlistCount !== null && waitlistCount !== undefined
                   ? ` (대기자 ${waitlistCount}명)`
                   : ''}
               </span>

--- a/src/components/EventDetailContent.tsx
+++ b/src/components/EventDetailContent.tsx
@@ -42,7 +42,7 @@ export function EventDetailContent({ view, event }: EventDetailContentProps) {
             </div>
             <span>
               {event.confirmedCount}/{event.capacity}명
-              {event.waitlistCount && event.waitlistCount > 0
+              {event.waitlistCount !== undefined
                 ? ` (대기자 ${event.waitlistCount}명)`
                 : ''}
             </span>
@@ -102,7 +102,7 @@ export function ShortEventDetailContent({
             </p>
             <p className="flex items-center gap-2">
               <User /> <p>정원</p> {event.confirmedCount}/{event.capacity}명
-              {event.waitlistCount && event.waitlistCount > 0
+              {event.waitlistCount !== undefined
                 ? ` (대기자 ${event.waitlistCount}명)`
                 : ''}
             </p>

--- a/src/mocks/handlers/registrations.ts
+++ b/src/mocks/handlers/registrations.ts
@@ -17,14 +17,14 @@ export const registrationHandlers = [
       .map((e) => ({
         publicId: e.event.publicId,
         title: e.event.title,
-        startAt: e.event.startsAt || '',
-        endAt: e.event.endsAt || '',
-        registrationStart: e.event.registrationStartsAt || '',
-        registrationDeadline: e.event.registrationEndsAt || '',
+        startsAt: e.event.startsAt || '',
+        endsAt: e.event.endsAt || '',
+        registrationStartsAt: e.event.registrationStartsAt || '',
+        registrationEndsAt: e.event.registrationEndsAt || '',
         capacity: e.event.capacity || 0,
         registrationCnt: e.event.confirmedCount || 0,
         status: e.viewer.status as 'CONFIRMED' | 'WAITLISTED' | 'CANCELED',
-        waitingNum: e.viewer.waitlistPosition,
+        waitlistedNum: e.viewer.waitlistPosition,
       }));
 
     const startIndex = page * size;

--- a/src/mocks/handlers/registrations.ts
+++ b/src/mocks/handlers/registrations.ts
@@ -22,7 +22,8 @@ export const registrationHandlers = [
         registrationStartsAt: e.event.registrationStartsAt || '',
         registrationEndsAt: e.event.registrationEndsAt || '',
         capacity: e.event.capacity || 0,
-        registrationCnt: e.event.confirmedCount || 0,
+        confirmedCount: e.event.confirmedCount || 0,
+        waitlistCount: e.event.waitlistCount || 0,
         status: e.viewer.status as 'CONFIRMED' | 'WAITLISTED' | 'CANCELED',
         waitlistedNum: e.viewer.waitlistPosition,
       }));

--- a/src/types/registrations.ts
+++ b/src/types/registrations.ts
@@ -9,14 +9,14 @@ export interface MyRegistrationsResponse {
 export interface MyRegistration {
   publicId: string;
   title: string;
-  startAt?: string;
-  endAt?: string;
-  registrationStart: string;
-  registrationDeadline: string;
+  startsAt?: string;
+  endsAt?: string;
+  registrationStartsAt: string;
+  registrationEndsAt: string;
   capacity: number;
   registrationCnt: number;
   status: 'CONFIRMED' | 'WAITLISTED' | 'CANCELED';
-  waitingNum?: number;
+  waitlistedNum?: number;
 }
 
 // ---------- GET /:id ----------

--- a/src/types/registrations.ts
+++ b/src/types/registrations.ts
@@ -14,7 +14,8 @@ export interface MyRegistration {
   registrationStartsAt: string;
   registrationEndsAt: string;
   capacity: number;
-  registrationCnt: number;
+  confirmedCount: number;
+  waitlistCount: number;
   status: 'CONFIRMED' | 'WAITLISTED' | 'CANCELED';
   waitlistedNum?: number;
 }


### PR DESCRIPTION
### 📝 작업 내용

- `GET /api/registrations/me`의 바뀐 API 응답 형식을 적용하였습니다.
- 대기자가 없는 경우 `(대기자 0명)`이라는 문구가 보이도록 했습니다.

### 📸 스크린샷

없음