### PR TITLE
🐛 Fix token expired modal

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -10,7 +10,7 @@ interface ApiErrorResponse {
 }
 
 const TIMEOUT = 10 * 1000; // 10sec
-const BUFFER_TIME = 10 * 60 * 1000; // 10min
+const BUFFER_TIME = 5 * 60 * 1000; // 5min
 
 // 공통 설정을 가진 axios 인스턴스 생성
 const apiClient = axios.create({

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -60,12 +60,20 @@ apiClient.interceptors.request.use((config) => {
 apiClient.interceptors.response.use(
   (response) => response,
   (error: AxiosError<ApiErrorResponse>) => {
+    // 1. 로컬에서 발생시킨 토큰 만료 에러인 경우 모달을 띄우지 않고 바로 reject
+    if (
+      error.message === 'TOKEN_EXPIRED_LOCAL' ||
+      error.message === 'INVALID_TOKEN_FORMAT'
+    ) {
+      return Promise.reject(error);
+    }
+
     const showError = useErrorStore.getState().showError;
 
     if (error.response?.data) {
       const { title, message, code } = error.response.data;
 
-      // 1. 토큰 만료 등 특수한 경우 확인 버튼 액션 정의
+      // 2. 토큰 만료 등 특수한 경우 확인 버튼 액션 정의
       let onConfirm = undefined;
       let confirmText = undefined;
       if (code === 'TOKEN_EXPIRED') {
@@ -75,7 +83,7 @@ apiClient.interceptors.response.use(
         confirmText = '다시 로그인하기';
       }
 
-      // 2. 스토어를 통해 모달 띄우기 (순서 주의: message, title, onConfirm, confirmText)
+      // 3. 스토어를 통해 모달 띄우기 (순서 주의: message, title, onConfirm, confirmText)
       showError(message, title || '오류 발생', onConfirm, confirmText);
     } else {
       // 서버 응답 자체가 없는 경우 (네트워크 오류 등)

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import axios from 'axios';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
@@ -29,6 +30,29 @@ const queryClient = new QueryClient({
     queries: {
       // 데이터가 5분 동안은 신선하다고 간주하여 불필요한 재요청 방지
       staleTime: 5 * 60 * 1000,
+      retry: (failureCount, error: unknown) => {
+        // 인증 관련 에러는 재시도하지 않음
+        if (error instanceof Error) {
+          if (
+            error.message === 'TOKEN_EXPIRED_LOCAL' ||
+            error.message === 'INVALID_TOKEN_FORMAT'
+          ) {
+            return false;
+          }
+        }
+
+        if (axios.isAxiosError(error)) {
+          if (
+            error.response?.status === 401 ||
+            error.response?.data?.code === 'TOKEN_EXPIRED'
+          ) {
+            return false;
+          }
+        }
+
+        // 그 외 에러는 기본값(3번) 재시도
+        return failureCount < 3;
+      },
     },
   },
 });


### PR DESCRIPTION
### 📝 작업 내용

- 토큰이 만료되었을 때 의도하지 않은 모달이 나타나는 문제를 해결했습니다.
- `TanStack Query(React Query)`를 기반으로 작동하는 api는 기본적으로 3번의 재시도를 수행하도록 설정되어있습니다.
  - `QueryClient `에 전역으로 `retry` 로직을 추가하여, 인증 관련 에러인 경우 즉시 재시도를 중단하도록 설정했습니다.
- 추가로, apiClient에서 `error.message`가 `TOKEN_EXPIRED_LOCAL`이거나 `INVALID_TOKEN_FORMAT`인 경우 에러 모달을 호출하지 않도록 설정했습니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 로컬에서 테스트해보았을 때는 문제가 없었지만, 실제 환경에서 다시 테스트를 진행해 보는 것이 좋을 것 같습니다.
