### PR TITLE
🐛 Fix token expired api

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -22,8 +22,15 @@ const apiClient = axios.create({
   headers: { 'Content-Type': 'application/json' },
 });
 
+// 토큰 만료 시 동시 다발적 API 요청을 막기 위한 플래그
+let isTokenExpiredLocal = false;
+
 // 요청 인터셉터: 모든 요청 직전에 실행됨
 apiClient.interceptors.request.use((config) => {
+  if (isTokenExpiredLocal) {
+    return Promise.reject(new Error('TOKEN_EXPIRED_LOCAL'));
+  }
+
   const { token, logout } = useAuthStore.getState();
 
   if (token) {
@@ -36,10 +43,14 @@ apiClient.interceptors.request.use((config) => {
 
         // 만료시간 5분 전(혹은 이미 지남)이면 거부
         if (expTimeMs - BUFFER_TIME - now <= 0) {
+          isTokenExpiredLocal = true;
+          // 1초 후 플래그 해제 (일시적 차단)
+          setTimeout(() => {
+            isTokenExpiredLocal = false;
+          }, 1000);
+
           // 상태 관리 로그아웃 처리만 수행
-          // 에러 모달(showError)과 리다이렉트(window.location.href)는
-          // 최상단 App.tsx에 마운트된 useAutoLogout 훅에서 일괄적으로 처리하도록 위임함.
-          // 여기서 중복 호출 시 모달이 2번 뜨는 Race Condition 발생 가능성 차단
+          // 에러 모달(showError)과 리다이렉트(window.location.href)는 응답 인터셉터에서 일괄 처리
           logout();
           return Promise.reject(new Error('TOKEN_EXPIRED_LOCAL'));
         }
@@ -60,15 +71,23 @@ apiClient.interceptors.request.use((config) => {
 apiClient.interceptors.response.use(
   (response) => response,
   (error: AxiosError<ApiErrorResponse>) => {
-    // 1. 로컬에서 발생시킨 토큰 만료 에러인 경우 모달을 띄우지 않고 바로 reject
+    const showError = useErrorStore.getState().showError;
+
+    // 1. 로컬에서 발생시킨 토큰 만료 에러인 경우 useAutoLogout과 동일한 모달을 띄우고 reject
     if (
       error.message === 'TOKEN_EXPIRED_LOCAL' ||
       error.message === 'INVALID_TOKEN_FORMAT'
     ) {
+      showError(
+        '로그인 유지 시간이 만료되어 자동으로 로그아웃되었습니다.',
+        '로그아웃 안내',
+        () => {
+          window.location.href = '/login';
+        },
+        '다시 로그인하기'
+      );
       return Promise.reject(error);
     }
-
-    const showError = useErrorStore.getState().showError;
 
     if (error.response?.data) {
       const { title, message, code } = error.response.data;


### PR DESCRIPTION
### 📝 작업 내용

- 기존에 로그인 토큰이 만료되어도, 최초 api 호출은 이루어지고 있어 그에 해당하는 백엔드의 '로그인이 필요합니다' 에러 모달이 나타나고 있었습니다.
- 로그인 토큰이 만료가 되면, 프론트 내부에서 api 호출이 안되게 차단합니다.
- 기존에 `hooks/useAutoLogout.ts` 내부에 '로그인 유지 시간이 만료되어 자동으로 로그아웃되었습니다.' 모달이 존재했는데, 이 모달은 페이지가 새로고침 되거나 탭을 이동할 때 작동한 것으로 추정됩니다.(이 로직은 유지했습니다)
- `apiClient`에서 로그인 토큰 만료를 감지하고, api 호출을 취소한 후 위와 동일한 모달을 띄웁니다.(로컬에서 확인했을 때 이 두 로직이 중복되는 문제는 없었습니다)

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

- 이번에도 로컬에서는 잘 작동했는데.... 실제 dev 환경에서 어떨지 모르겠네요.
- 만약 계속 문제가 발생하면 로컬에서 좀 더 정확하게 테스트해볼 수 있는 환경을 구축해보는 것도 고려해보면 좋을 것 같습니다.
