### PR TITLE
🚸 Refresh the dashboard after creating/deleting/joining/leaving an event

### DIFF
--- a/src/hooks/useEvent.ts
+++ b/src/hooks/useEvent.ts
@@ -11,7 +11,7 @@ export default function useEvent() {
       return response.data;
     },
     onSuccess: () => {
-      queryClient.removeQueries({ queryKey: ['myEvents'] });
+      queryClient.resetQueries({ queryKey: ['myEvents'] });
     },
   });
 

--- a/src/hooks/useEvent.ts
+++ b/src/hooks/useEvent.ts
@@ -1,27 +1,22 @@
 import { createEvent as createEventApi } from '@/api/events/event';
-import type { CreateEventRequest } from '@/types/events';
-import { useState } from 'react';
+import type { CreateEventRequest, CreateEventResponse } from '@/types/events';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 export default function useEvent() {
-  const [loading, setLoading] = useState(false);
+  const queryClient = useQueryClient();
 
-  const createEvent = async (
-    data: CreateEventRequest
-  ): Promise<string | null> => {
-    setLoading(true);
-    try {
+  const mutation = useMutation<CreateEventResponse, Error, CreateEventRequest>({
+    mutationFn: async (data) => {
       const response = await createEventApi(data);
-      return response.data.publicId;
-    } catch (error: unknown) {
-      console.error('Failed to create event:', error);
-      return null;
-    } finally {
-      setLoading(false);
-    }
-  };
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: ['myEvents'] });
+    },
+  });
 
   return {
-    loading,
-    createEvent,
+    loading: mutation.isPending,
+    createEvent: mutation.mutateAsync,
   };
 }

--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -109,6 +109,7 @@ export default function EventMain() {
 
     const success = await handleJoinEvent(id, {});
     if (success) {
+      queryClient.removeQueries({ queryKey: ['myRegistrations'] });
       toast.success('신청이 완료되었습니다.');
       navigate(0);
     }
@@ -123,6 +124,7 @@ export default function EventMain() {
 
     const success = await handleCancelEvent(regId);
     if (success) {
+      queryClient.removeQueries({ queryKey: ['myRegistrations'] });
       removeGuestRegistration(id);
       toast.success('신청이 취소되었습니다.');
     }
@@ -132,6 +134,7 @@ export default function EventMain() {
     const success = await handleDeleteEvent(id);
     if (success) {
       queryClient.removeQueries({ queryKey: ['myEvents'] });
+      queryClient.removeQueries({ queryKey: ['myRegistrations'] });
       toast.success('모임이 삭제되었습니다.');
       navigate('/');
     }

--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -8,6 +8,7 @@ import {
   X,
 } from 'lucide-react';
 import { type ComponentProps, useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router';
 import { toast } from 'sonner';
 
@@ -43,6 +44,7 @@ import { formatEventDate, getRemainingTime } from '@/utils/date';
 export default function EventMain() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const { isLoggedIn } = useAuth();
   const { removeGuestRegistration } = useAuthStore();
 
@@ -129,6 +131,7 @@ export default function EventMain() {
   const onDeleteClick = async () => {
     const success = await handleDeleteEvent(id);
     if (success) {
+      queryClient.removeQueries({ queryKey: ['myEvents'] });
       toast.success('모임이 삭제되었습니다.');
       navigate('/');
     }

--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { motion } from 'framer-motion';
 import {
   AlertCircle,
@@ -8,7 +9,6 @@ import {
   X,
 } from 'lucide-react';
 import { type ComponentProps, useEffect, useState } from 'react';
-import { useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router';
 import { toast } from 'sonner';
 

--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -109,7 +109,7 @@ export default function EventMain() {
 
     const success = await handleJoinEvent(id, {});
     if (success) {
-      queryClient.removeQueries({ queryKey: ['myRegistrations'] });
+      queryClient.resetQueries({ queryKey: ['myRegistrations'] });
       toast.success('신청이 완료되었습니다.');
       navigate(0);
     }
@@ -124,7 +124,7 @@ export default function EventMain() {
 
     const success = await handleCancelEvent(regId);
     if (success) {
-      queryClient.removeQueries({ queryKey: ['myRegistrations'] });
+      queryClient.resetQueries({ queryKey: ['myRegistrations'] });
       removeGuestRegistration(id);
       toast.success('신청이 취소되었습니다.');
     }
@@ -133,8 +133,8 @@ export default function EventMain() {
   const onDeleteClick = async () => {
     const success = await handleDeleteEvent(id);
     if (success) {
-      queryClient.removeQueries({ queryKey: ['myEvents'] });
-      queryClient.removeQueries({ queryKey: ['myRegistrations'] });
+      queryClient.resetQueries({ queryKey: ['myEvents'] });
+      queryClient.resetQueries({ queryKey: ['myRegistrations'] });
       toast.success('모임이 삭제되었습니다.');
       navigate('/');
     }

--- a/src/routes/EventRegister.tsx
+++ b/src/routes/EventRegister.tsx
@@ -5,6 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import useAuthStore from '@/hooks/useAuthStore';
 import type { JoinEventRequest } from '@/types/events';
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import { ShortEventDetailContent } from '../components/EventDetailContent';
@@ -14,6 +15,7 @@ import useEventDetail from '../hooks/useEventDetail';
 export default function EventRegister() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
   const setRedirectUrl = useAuthStore((state) => state.setRedirectUrl);
   const { loading, data, handleFetchDetail, handleJoinEvent } =
     useEventDetail();
@@ -60,6 +62,7 @@ export default function EventRegister() {
 
     const success = await handleJoinEvent(id, requestData);
     if (success) {
+      queryClient.removeQueries({ queryKey: ['myRegistrations'] });
       // 신청 성공 시 성공 페이지로 이동
       navigate(`/event/${id}`);
     }

--- a/src/routes/EventRegister.tsx
+++ b/src/routes/EventRegister.tsx
@@ -62,7 +62,7 @@ export default function EventRegister() {
 
     const success = await handleJoinEvent(id, requestData);
     if (success) {
-      queryClient.removeQueries({ queryKey: ['myRegistrations'] });
+      queryClient.resetQueries({ queryKey: ['myRegistrations'] });
       // 신청 성공 시 성공 페이지로 이동
       navigate(`/event/${id}`);
     }

--- a/src/routes/NewEvent.tsx
+++ b/src/routes/NewEvent.tsx
@@ -51,11 +51,12 @@ export default function NewEvent() {
       registrationEndsAt: data.regiEndDate.toISOString(),
     };
 
-    const eventId = await createEvent(payload);
-
-    if (eventId) {
+    try {
+      const { publicId } = await createEvent(payload);
       toast.success('모임이 성공적으로 생성되었습니다!');
-      navigate(`/event/${eventId}`);
+      navigate(`/event/${publicId}`);
+    } catch (error: unknown) {
+      console.error('Failed to create event:', error);
     }
   };
 


### PR DESCRIPTION
### 📝 작업 내용

- 모임 생성·삭제 작업을 마치고 대시보드 화면으로 돌아왔을 때, 생성·삭제한 결과가 대시보드에 반영되지 않아 사용자 경험이 저해되는 문제가 있었습니다. 탠스택 쿼리가 5분에 한 번씩 캐시를 갱신하는 것이 문제인 것으로 파악하였습니다.
- 이를 해결하기 위해, 모임을 생성하거나 삭제할 때 `myEvents` 캐시를 지우도록 했습니다. 그러면 대시보드를 로드할 때 가져올 캐시가 없으므로 항상 새로운 정보를 API에서 가져오게 됩니다.
- 이 과정에서, 캐시 관리를 쉽게 하기 위해 `useEvent` 훅을 탠스택 쿼리의 `useMutation` 기반으로 다시 작성하였습니다.

### 📸 스크린샷

없음

### 🚀 리뷰 요구사항

없음