### PR TITLE
✨ Add auto route guide

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -84,7 +84,8 @@ apiClient.interceptors.response.use(
         () => {
           window.location.href = '/login';
         },
-        '다시 로그인하기'
+        '다시 로그인하기',
+        '취소'
       );
       return Promise.reject(error);
     }
@@ -95,15 +96,17 @@ apiClient.interceptors.response.use(
       // 2. 토큰 만료 등 특수한 경우 확인 버튼 액션 정의
       let onConfirm = undefined;
       let confirmText = undefined;
+      let cancelText = undefined;
       if (code === 'TOKEN_EXPIRED') {
         onConfirm = () => {
           window.location.href = '/login';
         };
         confirmText = '다시 로그인하기';
+        cancelText = '취소';
       }
 
-      // 3. 스토어를 통해 모달 띄우기 (순서 주의: message, title, onConfirm, confirmText)
-      showError(message, title || '오류 발생', onConfirm, confirmText);
+      // 3. 스토어를 통해 모달 띄우기 (순서 주의: message, title, onConfirm, confirmText, cancelText, onCancel)
+      showError(message, title || '오류 발생', onConfirm, confirmText, cancelText);
     } else {
       // 서버 응답 자체가 없는 경우 (네트워크 오류 등)
       showError(

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -106,7 +106,13 @@ apiClient.interceptors.response.use(
       }
 
       // 3. 스토어를 통해 모달 띄우기 (순서 주의: message, title, onConfirm, confirmText, cancelText, onCancel)
-      showError(message, title || '오류 발생', onConfirm, confirmText, cancelText);
+      showError(
+        message,
+        title || '오류 발생',
+        onConfirm,
+        confirmText,
+        cancelText
+      );
     } else {
       // 서버 응답 자체가 없는 경우 (네트워크 오류 등)
       showError(

--- a/src/components/GlobalErrorModal.tsx
+++ b/src/components/GlobalErrorModal.tsx
@@ -1,6 +1,7 @@
 import {
   AlertDialog,
   AlertDialogAction,
+  AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,
   AlertDialogFooter,
@@ -10,7 +11,7 @@ import {
 import { useErrorStore } from '@/hooks/useErrorStore';
 
 export function GlobalErrorModal() {
-  const { isOpen, title, message, onConfirm, closeError, confirmText } =
+  const { isOpen, title, message, onConfirm, onCancel, closeError, confirmText, cancelText } =
     useErrorStore();
 
   const handleConfirm = () => {
@@ -20,6 +21,16 @@ export function GlobalErrorModal() {
 
     // 페이지 이동 등 무거운 작업이 발생할 때 리액트 렌더링 사이클이 꼬이면서
     // 빈 모달이 깜빡이는 현상(Race condition)을 막기 위해 약간의 딜레이를 두고 닫음
+    setTimeout(() => {
+      closeError();
+    }, 100);
+  };
+
+  const handleCancel = () => {
+    if (onCancel) {
+      onCancel();
+    }
+    
     setTimeout(() => {
       closeError();
     }, 100);
@@ -44,6 +55,11 @@ export function GlobalErrorModal() {
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
+          {cancelText && (
+            <AlertDialogCancel onClick={handleCancel}>
+              {cancelText}
+            </AlertDialogCancel>
+          )}
           <AlertDialogAction onClick={handleConfirm} autoFocus>
             {confirmText}
           </AlertDialogAction>

--- a/src/components/GlobalErrorModal.tsx
+++ b/src/components/GlobalErrorModal.tsx
@@ -11,8 +11,16 @@ import {
 import { useErrorStore } from '@/hooks/useErrorStore';
 
 export function GlobalErrorModal() {
-  const { isOpen, title, message, onConfirm, onCancel, closeError, confirmText, cancelText } =
-    useErrorStore();
+  const {
+    isOpen,
+    title,
+    message,
+    onConfirm,
+    onCancel,
+    closeError,
+    confirmText,
+    cancelText,
+  } = useErrorStore();
 
   const handleConfirm = () => {
     if (onConfirm) {
@@ -30,7 +38,7 @@ export function GlobalErrorModal() {
     if (onCancel) {
       onCancel();
     }
-    
+
     setTimeout(() => {
       closeError();
     }, 100);

--- a/src/components/auth/PrivateRoute.tsx
+++ b/src/components/auth/PrivateRoute.tsx
@@ -1,0 +1,12 @@
+import useAuthStore from '@/hooks/useAuthStore';
+import { Navigate, Outlet } from 'react-router';
+
+export default function PrivateRoute() {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+
+  if (!isLoggedIn) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/components/auth/PrivateRoute.tsx
+++ b/src/components/auth/PrivateRoute.tsx
@@ -5,7 +5,7 @@ export default function PrivateRoute() {
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
 
   if (!isLoggedIn) {
-    return <Navigate to="/login" replace />;
+    return <Navigate to="/" replace />;
   }
 
   return <Outlet />;

--- a/src/components/auth/PublicOnlyRoute.tsx
+++ b/src/components/auth/PublicOnlyRoute.tsx
@@ -1,0 +1,12 @@
+import useAuthStore from '@/hooks/useAuthStore';
+import { Navigate, Outlet } from 'react-router';
+
+export default function PublicOnlyRoute() {
+  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
+
+  if (isLoggedIn) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+}

--- a/src/hooks/useAutoLogout.ts
+++ b/src/hooks/useAutoLogout.ts
@@ -61,7 +61,8 @@ export function useAutoLogout() {
         () => {
           window.location.href = '/login';
         },
-        '다시 로그인하기'
+        '다시 로그인하기',
+        '취소'
       );
     };
 

--- a/src/hooks/useErrorStore.ts
+++ b/src/hooks/useErrorStore.ts
@@ -35,7 +35,15 @@ export const useErrorStore = create<ErrorState>((set) => ({
     cancelText,
     onCancel
   ) => {
-    set({ isOpen: true, message, title, onConfirm, confirmText, cancelText, onCancel });
+    set({
+      isOpen: true,
+      message,
+      title,
+      onConfirm,
+      confirmText,
+      cancelText,
+      onCancel,
+    });
   },
   closeError: () => set({ isOpen: false }), // 리다이렉트 중 깜빡임 방지를 위해 내용 보존
 }));

--- a/src/hooks/useErrorStore.ts
+++ b/src/hooks/useErrorStore.ts
@@ -5,12 +5,16 @@ interface ErrorState {
   title: string;
   message: string;
   confirmText: string;
+  cancelText?: string;
   onConfirm?: () => void; // 확인 버튼 클릭 시 실행할 콜백 함수
+  onCancel?: () => void; // 취소 버튼 클릭 시 실행할 콜백 함수
   showError: (
     message: string,
     title?: string,
     onConfirm?: () => void,
-    confirmText?: string
+    confirmText?: string,
+    cancelText?: string,
+    onCancel?: () => void
   ) => void;
   closeError: () => void;
 }
@@ -20,14 +24,18 @@ export const useErrorStore = create<ErrorState>((set) => ({
   title: '오류 발생',
   message: '',
   confirmText: '확인',
+  cancelText: undefined,
   onConfirm: undefined,
+  onCancel: undefined,
   showError: (
     message,
     title = '오류 발생',
     onConfirm,
-    confirmText = '확인'
+    confirmText = '확인',
+    cancelText,
+    onCancel
   ) => {
-    set({ isOpen: true, message, title, onConfirm, confirmText });
+    set({ isOpen: true, message, title, onConfirm, confirmText, cancelText, onCancel });
   },
   closeError: () => set({ isOpen: false }), // 리다이렉트 중 깜빡임 방지를 위해 내용 보존
 }));

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,3 +1,5 @@
+import PrivateRoute from '@/components/auth/PrivateRoute';
+import PublicOnlyRoute from '@/components/auth/PublicOnlyRoute';
 import RootLayout from '@/layouts/RootLayout';
 import EventEdit from '@/routes/EventEdit';
 import EventMain from '@/routes/EventMain';
@@ -20,26 +22,40 @@ export const router = createBrowserRouter([
     Component: RootLayout,
     children: [
       { index: true, Component: Home },
-      { path: 'login', Component: Login, handle: { title: '로그인 - 모이밍' } },
       {
-        path: 'sign-up',
-        Component: SignUp,
-        handle: { title: '회원가입 - 모이밍' },
+        Component: PublicOnlyRoute,
+        children: [
+          {
+            path: 'login',
+            Component: Login,
+            handle: { title: '로그인 - 모이밍' },
+          },
+          {
+            path: 'sign-up',
+            Component: SignUp,
+            handle: { title: '회원가입 - 모이밍' },
+          },
+          {
+            path: 'auth/verify',
+            Component: VerifyEmail,
+            handle: { title: '이메일 인증 - 모이밍' },
+          },
+          {
+            path: 'auth/callback/:provider',
+            Component: SocialCallback,
+            handle: { title: '소셜 로그인 - 모이밍' },
+          },
+        ],
       },
       {
-        path: 'auth/verify',
-        Component: VerifyEmail,
-        handle: { title: '이메일 인증 - 모이밍' },
-      },
-      {
-        path: 'auth/callback/:provider',
-        Component: SocialCallback,
-        handle: { title: '소셜 로그인 - 모이밍' },
-      },
-      {
-        path: 'profile',
-        Component: ProfileEdit,
-        handle: { title: '프로필 수정 - 모이밍' },
+        Component: PrivateRoute,
+        children: [
+          {
+            path: 'profile',
+            Component: ProfileEdit,
+            handle: { title: '프로필 수정 - 모이밍' },
+          },
+        ],
       },
       {
         path: '*',
@@ -51,7 +67,12 @@ export const router = createBrowserRouter([
   {
     path: '/new-event',
     Component: RootLayout,
-    children: [{ index: true, Component: NewEvent }],
+    children: [
+      {
+        Component: PrivateRoute,
+        children: [{ index: true, Component: NewEvent }],
+      },
+    ],
     handle: { title: '모임 만들기 - 모이밍' },
   },
   {
@@ -61,7 +82,10 @@ export const router = createBrowserRouter([
       { index: true, Component: EventMain },
       { path: 'guests', Component: Guests },
       { path: 'register', Component: EventRegister },
-      { path: 'edit', Component: EventEdit },
+      {
+        Component: PrivateRoute,
+        children: [{ path: 'edit', Component: EventEdit }],
+      },
     ],
     handle: { title: '모임 상세 - 모이밍' },
   },


### PR DESCRIPTION
### 📝 작업 내용

- 로그인 유저와 비로그인 유저가 접근할 수 있는 페이지에 제한을 두어, 적절하지 않은 페이지로 이동할 경우 즉시 리다이렉트 되도록 수정했습니다.

- `PrivateRoute`를 이용해서, `/profile`, `/new-event`, `/event/:id/edit` 페이지에 비로그인 유저가 접근할 경우 즉시 `/login` 로그인페이지로 이동합니다.
`/event/:id`와 `/event/:id/register`는 게스트 조회 및 신청을 위해 예외로 두었습니다.

- `PublicOnlyRoute`를 이용해서, `/login`, `/sign-up`, `/auth/verify`, `/auth/callback/:provider` 페이지에 로그인 유저가 접근한 경우 즉시 `/` 랜딩페이지로 이동합니다.

### 📸 스크린샷 (선택)

### 🚀 리뷰 요구사항 (선택)

### 알림 없는 리다이렉트
현재 두 로직 모두 사용자에게 별다른 알림을 띄우지 않고, 즉시 리다이렉트를 실행합니다.

이를 위해서 접근 거부시 `toast.error('로그인이 필요합니다.')` 등의 토스트 알림을 띄우는 것을 고려해보았는데, 기존에 존재하는 로그인 토큰 만료 모달과 중복해서 나타날 위험이 있을 것 같아 반려했습니다.

다음과 같은 3가지 방안을 고려해보았는데, 어떻게 생각하시나요?
 1. 로그인 토큰 만료 모달과 중복되더라도 리다이렉트시 토스트 알림을 표시
 2. 로그인 토큰 만료 모달 삭제하고, 이번 작업에서 접근제한+리다이렉트시 토스트(or 모달) 표시로 통일
 3. 이번 작업의 알림 없이 리다이렉트 실행을 유지

## 로그인 토큰 만료 모달과 중복
기존의 로그인 토큰 만료 모달에서 `취소`와 `다시 로그인하기` 버튼이 생성되고 `취소`를 누르면, 기존 페이지, `다시 로그인하기`를 누르면 `/login`으로 이동합니다.

그런데, 이번 작업을 도입하면 로그인 토큰 만료 모달이 나타날 때 적절하지 않은 페이지였다면, 그 즉시 `PrivateRoute`가 작동하여 `/login`으로 리다이렉트되고(알림 없이), 배경이 로그인 페이지로 바뀐 상태에서 로그인 토큰 만료 모달이 나타납니다.
`취소`를 누르면 기존 페이지가 아닌 `/login`에서 이동이 일어나지 않는 것으로 처리가 되고, 만약 `다시 로그인하기`를 누르면 `/login` 페이지에서 한 번 더 새로고침이 발생합니다.

뭔가 말하다 보니 로그인 토큰 만료 모달이 만악의 근원 같은 느낌도 드는데.... 어떻게 생각하시나요?

(사실 기존 로직을 그대로 유지해도 사용성에서 큰 문제는 없을 것 같기도 합니다 ex)event/@ 페이지같이 적절한 페이지를 보던 도중 로그인 토큰이 만료가 되면, 그럴때는 모달의 `취소`와 `다시 로그인하기`가 의도대로 작동하고, 아예 없애면 이런 경우 문제가 발생할지도...?)
