### PR TITLE
🐛 Remove redundant fetch call after registration cancel

### DIFF
--- a/src/hooks/useEventDetail.ts
+++ b/src/hooks/useEventDetail.ts
@@ -140,7 +140,6 @@ export default function useEventDetail(id?: string) {
       await deleteRegistration(registrationId);
       if (id) {
         removeGuestRegistration(id);
-        await handleFetchDetail(id);
       }
       return true;
     } catch (error) {

--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -248,13 +248,15 @@ function StatusBanner({
   name,
   email,
 }: { view: EventViewType; waitingNum?: number; name: string; email: string }) {
+  if (view === 'ADMIN') return null;
+
   if (
     view !== 'CONFIRMED' &&
     view !== 'WAITLISTED' &&
     view !== 'CANCELED' &&
     view !== 'BANNED'
   )
-    return null;
+    return <div />;
 
   const config = {
     CONFIRMED: {


### PR DESCRIPTION
### 📝 작업 내용

- 모임 참여를 취소할 때 '존재하지 않는 이벤트입니다.' 오류 모달이 나타나는 문제를 해결하였습니다.
  - `handleCancelEvent`는 참여를 취소한 후 `handleFetchDetail(id)`를 명시적으로 호출하는데, 이 함수 내부에서 삭제된 정보로 다시 조회하려 하면서 404 에러가 발생하고 있었습니다.
  - 또, 참여를 취소하는 과정에서 상태가 변경되면 `effectiveRegId`가 갱신되고 `handleFetchDetail`이 새롭게 생성됩니다. 이때 `EventMain.tsx`의 `useEffect`는 `handleFetchDetail`을 의존성으로 갖고 있기 때문에, `handleFetchDetail(id)`를 명시적으로 호출하지 않아도 페치가 일어납니다.
  - 따라서 `handleCancelEvent` 안의 `handleFetchDetail(id)` 호출을 제거하는 방식으로 문제를 해결하였습니다.
- 모임 메인 화면에서, 내비게이션 바도 상태 배너도 없는 경우 상단 여백이 없다는 문제점이 있었습니다. 이를 해결하였습니다.

### 📸 스크린샷

<img width="306" height="584.5" alt="스크린샷 2026-05-16 21 57 52" src="https://github.com/user-attachments/assets/7ead1b77-856d-4a2f-a4d2-9aeb3f83049f" />


### 🚀 리뷰 요구사항

없음