### PR TITLE
🩹 Show reservation email in `EventMain`

### DIFF
--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -45,7 +45,7 @@ export default function EventMain() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { isLoggedIn } = useAuth();
+  const { user, isLoggedIn } = useAuth();
   const { removeGuestRegistration } = useAuthStore();
 
   // 1. 데이터 가져오기 및 권한 확인
@@ -107,7 +107,10 @@ export default function EventMain() {
     // 비로그인이면 폼 입력 페이지로 이동
     if (!isLoggedIn) return navigate(`/event/${id}/register`);
 
-    const success = await handleJoinEvent(id, {});
+    const success = await handleJoinEvent(id, {
+      guestName: user?.name,
+      guestEmail: user?.email,
+    });
     if (success) {
       queryClient.resetQueries({ queryKey: ['myRegistrations'] });
       toast.success('신청이 완료되었습니다.');
@@ -172,8 +175,8 @@ export default function EventMain() {
         <StatusBanner
           view={view}
           waitingNum={viewer.waitlistPosition}
-          name={viewer.name}
-          email={viewer.reservationEmail}
+          name={viewer.name ?? user?.name}
+          email={viewer.reservationEmail ?? user?.email}
         />
 
         <section className="flex flex-col gap-4">


### PR DESCRIPTION
### 📝 작업 내용

- 로그인 사용자가 모임을 신청한 경우, 예약정보 전달 이메일이 나타나지 않는다는 문제가 있었습니다.
- 표면적으로는 페이로드의 `viewer.reservationEmail` 필드가 `null`이라 발생하는 문제인데요, 명확한 원인은 백엔드 분들과 얘기를 해봐야 알 수 있을 것 같습니다.
- 이번 PR에서는 임시방편으로, 예약정보 전달 이메일에 로그인된 사용자의 이메일이 보이도록 하였습니다. 로그인한 사용자가 자신의 것이 아닌 이메일로 모임을 신청하는 방법이 존재하는지는 모르겠습니다만, 그런 통로가 발견된다면 추가 수정이 필요할 듯합니다.

### 📸 스크린샷

<img width="306" height="584.5" alt="스크린샷 2026-05-16 22 38 04" src="https://github.com/user-attachments/assets/a6eeacbf-6371-4c98-a920-83207717fda8" />

### 🚀 리뷰 요구사항

없음