### PR TITLE
💄 Add padding to `EventForm` to prevent footer-content overlap

### DIFF
--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -333,7 +333,7 @@ export function EventForm({
         </div>
 
         {/* Form */}
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <form onSubmit={handleSubmit(onSubmit)} className="pb-24">
           {/* STEP 1: Basic Info */}
           {step === 1 && (
             <FieldGroup className="flex flex-col rounded-lg p-6 gap-6 border border-border">
@@ -623,7 +623,7 @@ export function EventForm({
 
       {/* Action area */}
       <footer className="fixed bottom-0 left-0 right-0 z-10">
-        <div className="h-6 bg-gradient-to-t from-white to-transparent" />
+        <div className="h-6 bg-linear-to-t from-white to-transparent" />
         {step === 1 && (
           <div className="flex bg-white p-4 justify-center items-center gap-2 max-w-2xl mx-auto">
             <Button type="button" size="xl" className="w-full" onClick={onNext}>


### PR DESCRIPTION
### 📝 작업 내용

- `EventForm` 컴포넌트 가장 아래에 24px의 여백을 주었습니다.

### 📸 스크린샷

- 아래는 iPhone SE의 화면 크기를 기준으로 한 것입니다.

<img width="373" height="661" alt="스크린샷 2026-05-30 19 55 55" src="https://github.com/user-attachments/assets/ea8106b2-87cc-4574-8992-666828d7141d" />

### 🚀 리뷰 요구사항

없음