### PR TITLE
💄 Fix minor typos across the app

### DIFF
--- a/src/routes/EventMain.tsx
+++ b/src/routes/EventMain.tsx
@@ -371,7 +371,7 @@ ${event.description}`;
     navigator.clipboard.writeText(textToCopy);
     toast.success('링크가 복사되었습니다!', {
       description: copyDetail
-        ? '모임 내용이 포함되었습니다.'
+        ? '모임 상세정보가 포함되었습니다.'
         : '참여자에게 주소를 공유해 보세요.',
     });
   };
@@ -424,7 +424,7 @@ ${event.description}`;
             htmlFor="copy"
             className="body-base text-[#1e1e1e] cursor-pointer"
           >
-            모임 내용 텍스트 함께 복사하기
+            모임 상세정보 함께 복사하기
           </label>
         </div>
         <Button

--- a/src/routes/Guests.tsx
+++ b/src/routes/Guests.tsx
@@ -178,7 +178,11 @@ export default function Guests() {
               목록을 더 불러오고 있습니다...
             </p>
           ) : (
-            <p className="text-gray-400 text-sm">마지막 참여자입니다.</p>
+            <p className="text-gray-400 text-sm">
+              {activeTab === 'WAITLISTED'
+                ? '마지막 대기자입니다.'
+                : '마지막 참여자입니다.'}
+            </p>
           )}
         </div>
       </div>

--- a/src/routes/Login.tsx
+++ b/src/routes/Login.tsx
@@ -45,7 +45,7 @@ export default function Login() {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
-                placeholder="8자 이상, 숫자 포함"
+                placeholder="8자 이상, 영문, 숫자 포함"
                 required
               />
             </Field>

--- a/src/routes/ProfileEdit.tsx
+++ b/src/routes/ProfileEdit.tsx
@@ -195,9 +195,13 @@ export default function SignUp() {
                   {validations.password.isLongEnough ? '✓' : '○'} 8자 이상
                 </li>
                 <li
-                  className={`text-xs flex items-center ${validations.password.hasNumber ? 'text-green-600' : 'text-gray-400'}`}
+                  className={
+                    validations.password.hasNumber
+                      ? 'text-green-500'
+                      : 'text-gray-400'
+                  }
                 >
-                  {validations.password.hasNumber ? '✓' : '○'} 숫자 포함
+                  {validations.password.hasNumber ? '✓' : '○'} 영문, 숫자 포함
                 </li>
               </ul>
             )}

--- a/src/routes/SignUp.tsx
+++ b/src/routes/SignUp.tsx
@@ -222,7 +222,7 @@ export default function SignUp() {
               }`}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              placeholder="8자 이상, 숫자 포함"
+              placeholder="8자 이상, 영문, 숫자 포함"
             />
 
             {showErrors && !password && (
@@ -238,7 +238,7 @@ export default function SignUp() {
                 <li
                   className={`text-xs flex items-center ${validations.password.hasNumber ? 'text-green-600' : 'text-gray-400'}`}
                 >
-                  {validations.password.hasNumber ? '✓' : '○'} 숫자 포함
+                  {validations.password.hasNumber ? '✓' : '○'} 영문, 숫자 포함
                 </li>
               </ul>
             )}


### PR DESCRIPTION
### 📝 작업 내용

앱 내 전반적으로 적절하지 않은 문구를 수정했습니다.

- 모임 상세 정보 문구 변경 (`EventMain.tsx`)
  - 체크박스 라벨: 모임 내용 텍스트 함께 복사하기 -> 모임 상세정보 함께 복사하기
  - 복사 토스트 알림: 모임 내용이 포함되었습니다. -> 모임 상세정보가 포함되었습니다.
- 비밀번호 유효성 검사 문구 강화 (`SignUp.tsx`, `ProfileEdit.tsx`, `Login.tsx`)
  - Placeholder: 8자 이상, 숫자 포함 -> 8자 이상, 영문, 숫자 포함
  - 유효성 검사 텍스트: {...} 숫자 포함 -> {...} 영문, 숫자 포함
- 대기자 명단 하단 텍스트 분기 처리 (`Guests.tsx`)
  - 무한 스크롤 하단에 노출되는 텍스트를 현재 활성화된 탭(`activeTab`)이 `WAITLISTED`인지에 따라 동적으로 변경하도록 처리했습니다.
  - 적용 로직: `{activeTab === 'WAITLISTED' ? '마지막 대기자입니다.' : '마지막 참여자입니다.'}`

### 📸 스크린샷 (선택)
<img width="570" height="186" alt="스크린샷 2026-06-06 160855" src="https://github.com/user-attachments/assets/11778908-4f2d-435a-a1ed-296461048f70" />
<img width="620" height="124" alt="스크린샷 2026-06-06 160933" src="https://github.com/user-attachments/assets/5a8ebd73-b718-4d6b-a22a-4e0b34f81370" />
<img width="626" height="187" alt="스크린샷 2026-06-06 160939" src="https://github.com/user-attachments/assets/c7b8fd47-02b1-413c-976f-d132d1e2492e" />
<img width="969" height="268" alt="스크린샷 2026-06-06 160903" src="https://github.com/user-attachments/assets/ab4bf31f-afd6-467f-97f1-f8364ec47df8" />

### 🚀 리뷰 요구사항 (선택)
