### PR TITLE
🐛 Fix EventEdit save bugs

### DIFF
--- a/src/components/EventForm.tsx
+++ b/src/components/EventForm.tsx
@@ -232,7 +232,8 @@ export function EventForm({
     // 1단계 필드만 검증
     const isValidStep1 = await trigger([
       'title',
-      'capacity',
+      'location',
+      'description',
       'eventStartDate',
       'eventEndDate',
     ]);
@@ -241,7 +242,8 @@ export function EventForm({
       // 추가적으로 zod superRefine의 에러도 확인해야 함
       const step1Errors = [
         errors.title,
-        errors.capacity,
+        errors.location,
+        errors.description,
         errors.eventStartDate,
         errors.eventEndDate,
       ];
@@ -444,10 +446,20 @@ export function EventForm({
                           {...field}
                           id="location"
                           placeholder="어디서 모이나요? (최대 20자)"
+                          className={`${
+                            errors.location
+                              ? 'border-destructive focus:ring-destructive/10'
+                              : ''
+                          }`}
                           value={field.value ?? ''}
                         />
                       )}
                     />
+                    {errors.location && (
+                      <p className={errorTextStyle}>
+                        {errors.location.message}
+                      </p>
+                    )}
                   </Field>
 
                   {/* Description */}
@@ -461,11 +473,20 @@ export function EventForm({
                           {...field}
                           id="description"
                           placeholder="이번 모임은 어떤 모임인가요? 모임을 설명해 주세요."
-                          className="h-20 body-base"
+                          className={`h-20 body-base ${
+                            errors.description
+                              ? 'border-destructive focus:ring-destructive/10'
+                              : ''
+                          }`}
                           value={field.value ?? ''}
                         />
                       )}
                     />
+                    {errors.description && (
+                      <p className={errorTextStyle}>
+                        {errors.description.message}
+                      </p>
+                    )}
                   </Field>
                 </FieldGroup>
               </FieldSet>

--- a/src/routes/EventEdit.tsx
+++ b/src/routes/EventEdit.tsx
@@ -98,8 +98,8 @@ export default function EventEdit() {
     try {
       const payload = {
         title: formData.title.trim(),
-        location: formData.location?.trim() || undefined,
-        description: formData.description?.trim() || undefined,
+        location: formData.location?.trim() || '',
+        description: formData.description?.trim() || '',
         startsAt: formData.eventStartDate.toISOString(),
         endsAt:
           formData.isBounded && formData.eventEndDate


### PR DESCRIPTION
### 📝 작업 내용

- `EventEdit.tsx`에서 서버에 보낼 payload를 구성할 때, 빈 문자열인 경우 `undefined` 가 아닌 ''(빈 문자열)을 할당하도록 수정했습니다.
  - `NewEvent.tsx`에서도 비슷한 상황에서 `undefined`를 반환하지만, 일정 생성 시에는 현재 코드를 유지해도 괜찮을 것 같아 수정하지 않았습니다.
  - 기존 '미정' 등으로 표시되는 부분은 자바스크립트에서 `' '`(빈 문자열)도 `falsy`로 평가하여 문제가 없을 것으로 예상됩니다.
- `EventForm.tsx`에서 1단계 유효성 검사 필드에 `location`/`description` 추가하고 `capacity` 삭제하였습니다.
- 1단계 필드에서 `location`과 `description` 입력 폼 하단에 에러 메세지 ui를 출력하는 기능을 추가했습니다.(`description`는 확장성을 위해 추가했습니다. 현재는 특별한 유효성 검사를 실행하지 않습니다.)

### 📸 스크린샷 (선택)
<img width="916" height="152" alt="image" src="https://github.com/user-attachments/assets/290843e2-614f-4b16-add6-8eb6b83d9f74" />

### 🚀 리뷰 요구사항 (선택)

